### PR TITLE
Remove unnecessary CaloPreShowerSDAction, use MultiCollections inside ILD module if needed.

### DIFF
--- a/StandardConfig/lcgeo_current/ddsim_steer.py
+++ b/StandardConfig/lcgeo_current/ddsim_steer.py
@@ -19,7 +19,6 @@ SIM.crossingAngleBoost = 7.e-3*rad
 SIM.action.tracker = ("Geant4TrackerWeightedAction", {"HitPositionCombination" : 2 , "CollectSingleDeposits" :  False } )
 
 SIM.action.mapActions['tpc'] = "TPCSDAction"
-#SIM.action.mapActions['ecal'] = ( "CaloPreShowerSDAction", {"FirstLayerNumber": 0} )
 
 SIM.filter.mapDetFilter['TPC'] = "edep0"
 


### PR DESCRIPTION
Remove unnecessary CaloPreShowerSDAction, use MultiCollections inside ILD module if needed.



BEGINRELEASENOTES
- Remove unnecessary CaloPreShowerSDAction.
   - use MultiCollections inside ILD module if needed.
   - use same "ddsim_steer.py" for all ILD modules without confusion.

ENDRELEASENOTES