### PR TITLE
 Follow the ECAL driver update, and change the ECAL 'calibration_laye…

### DIFF
--- a/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
+++ b/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
@@ -1222,7 +1222,7 @@
     <parameter name="inputRelationCollections"> EcalBarrelRelationsSimDigi </parameter>
     <parameter name="outputHitCollections"> EcalBarrelCollectionRec </parameter>
     <parameter name="outputRelationCollections"> EcalBarrelRelationsSimRec </parameter>
-    <parameter name="calibration_layergroups"> 20 11 </parameter>
+    <parameter name="calibration_layergroups"> 21 11 </parameter>
     <parameter name="calibration_factorsMipGev"> 0.00616054 0.0125136 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
@@ -1252,7 +1252,7 @@
     <parameter name="inputRelationCollections"> EcalEndcapsRelationsSimDigi </parameter>
     <parameter name="outputHitCollections"> EcalEndcapsCollectionRec </parameter>
     <parameter name="outputRelationCollections"> EcalEndcapsRelationsSimRec </parameter>
-    <parameter name="calibration_layergroups"> 20 11 </parameter>
+    <parameter name="calibration_layergroups"> 21 11 </parameter>
     <parameter name="calibration_factorsMipGev"> 0.00616054 0.0125136 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
@@ -1282,7 +1282,7 @@
     <parameter name="inputRelationCollections"> EcalEndcapRingRelationsSimDigi </parameter>
     <parameter name="outputHitCollections"> EcalEndcapRingCollectionRec </parameter>
     <parameter name="outputRelationCollections"> EcalEndcapRingRelationsSimRec </parameter>
-    <parameter name="calibration_layergroups"> 20 11 </parameter>
+    <parameter name="calibration_layergroups"> 21 11 </parameter>
     <parameter name="calibration_factorsMipGev"> 0.00616054 0.0125136 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>


### PR DESCRIPTION
…rgroups' configuration.



BEGINRELEASENOTES
- Follow the ECAL driver update, and change the ECAL 'calibration_layergroups' configuration.
- The update ECAL driver has 21 [thin 2.1mm] absorbers.

ENDRELEASENOTES