### PR TITLE
Ecal calibration updates for ILD_l4_v02 model

### DIFF
--- a/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
+++ b/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
@@ -1503,7 +1503,7 @@
     <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
     <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
     <!-- Calibration constants -->
-    <parameter name="ECalToMipCalibration" type="float">147.58</parameter>
+    <parameter name="ECalToMipCalibration" type="float">156.88</parameter>
     <parameter name="HCalToMipCalibration" type="float">40.4858</parameter>
     <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
     <parameter name="ECalMipThreshold" type="float">0.5</parameter>

--- a/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
+++ b/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
@@ -1213,7 +1213,7 @@
     <parameter name="outputRelationCollections"> EcalBarrelRelationsSimDigi </parameter>
     <parameter name="threshold"> 0.5 </parameter>
     <parameter name="timingCut"> 1  </parameter>
-    <parameter name="calibration_mip"> 0.0001475  </parameter>
+    <parameter name="calibration_mip"> 0.0001525 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
   <!-- reconstruction -->
@@ -1223,7 +1223,7 @@
     <parameter name="outputHitCollections"> EcalBarrelCollectionRec </parameter>
     <parameter name="outputRelationCollections"> EcalBarrelRelationsSimRec </parameter>
     <parameter name="calibration_layergroups"> 20 11 </parameter>
-    <parameter name="calibration_factorsMipGev"> 0.00616054 0.0125136 </parameter>
+    <parameter name="calibration_factorsMipGev"> 0.00637432 0.01274865 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
   <!-- gap filling -->
@@ -1243,7 +1243,7 @@
     <parameter name="outputRelationCollections"> EcalEndcapsRelationsSimDigi </parameter>
     <parameter name="threshold"> 0.5 </parameter>
     <parameter name="timingCut"> 1  </parameter>
-    <parameter name="calibration_mip"> 0.0001475  </parameter>
+    <parameter name="calibration_mip"> 0.0001525 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
   <!-- reconstruction -->
@@ -1253,7 +1253,7 @@
     <parameter name="outputHitCollections"> EcalEndcapsCollectionRec </parameter>
     <parameter name="outputRelationCollections"> EcalEndcapsRelationsSimRec </parameter>
     <parameter name="calibration_layergroups"> 20 11 </parameter>
-    <parameter name="calibration_factorsMipGev"> 0.00616054 0.0125136 </parameter>
+    <parameter name="calibration_factorsMipGev"> 0.00637432 0.01274865 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
   <!-- gap filling -->
@@ -1273,7 +1273,7 @@
     <parameter name="outputRelationCollections"> EcalEndcapRingRelationsSimDigi </parameter>
     <parameter name="threshold"> 0.5 </parameter>
     <parameter name="timingCut"> 1  </parameter>
-    <parameter name="calibration_mip"> 0.0001475  </parameter>
+    <parameter name="calibration_mip"> 0.0001525 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
   <!-- reconstruction -->
@@ -1283,7 +1283,7 @@
     <parameter name="outputHitCollections"> EcalEndcapRingCollectionRec </parameter>
     <parameter name="outputRelationCollections"> EcalEndcapRingRelationsSimRec </parameter>
     <parameter name="calibration_layergroups"> 20 11 </parameter>
-    <parameter name="calibration_factorsMipGev"> 0.00616054 0.0125136 </parameter>
+    <parameter name="calibration_factorsMipGev"> 0.00637432 0.01274865 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
 
@@ -1503,12 +1503,12 @@
     <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
     <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
     <!-- Calibration constants -->
-    <parameter name="ECalToMipCalibration" type="float">158.73</parameter>
+    <parameter name="ECalToMipCalibration" type="float">147.58</parameter>
     <parameter name="HCalToMipCalibration" type="float">40.4858</parameter>
     <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
     <parameter name="ECalMipThreshold" type="float">0.5</parameter>
     <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-    <parameter name="ECalToEMGeVCalibration" type="float">1.0505</parameter>
+    <parameter name="ECalToEMGeVCalibration" type="float">1.</parameter>
     <parameter name="HCalToEMGeVCalibration" type="float">1.04898</parameter>
     <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.21826</parameter>
     <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.21826</parameter>


### PR DESCRIPTION
BEGINRELEASENOTES
- Updated Ecal calibration constants to reflect the ecal sensitive layer thickness change (+5%) in this ILD model
- Changed mip calibration constant in digitizer
- Changed ecal energy factors in digitizers
- Changed ECal mip scale in DDMarlinPandora accordingly
- Changed ECalToEmGeV in DDMarlinPandora to 1 to reflect what is done in the calibration procedure 
ENDRELEASENOTES