### PR TITLE
add stdreco file for ILD_ls5_v02 models w/ hybrid ecal

### DIFF
--- a/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_hybridecal.xml
+++ b/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_hybridecal.xml
@@ -1,0 +1,2076 @@
+<!--
+   Standard steering file to run a new standard reconstruction
+   using DDRec on events simulated with DD4hep/lcgeo for
+   detectors ILD_l5_v02 and ILD_s5_v02 with a hybrid Ecal
+   
+   Based on bbudsc_3evt_stdreco.xml form ILDconfig
+   
+   Status:  - experimental
+   
+   @author F.Gaede, DESY
+   @date July, 2017
+  -->
+
+
+<marlin>
+  
+  <execute>
+    <processor name="MyAIDAProcessor"/>
+    
+    <processor name="InitDD4hep"/>
+    
+    <processor name="MyStatusmonitor" />
+    
+    <!-- =========  overlay gamma gamma background  === -->
+
+    <!-- ###### activate for production ! ########## -->
+    <!-- <processor name="BgOverlay" /> -->
+    <!-- ########################################### -->
+
+
+    <processor name="MySplitCollectionByLayer" />
+    
+    <!-- ========== track digitization and tracking  === -->
+    <!-- concerning the VXD digitisation, one can use one of the following VXD models-->
+    <!-- DBD VXD, conservative CMOS design and ambitious CMOS design, cf  -->
+    <!-- please not forget to consider the corresponding time resolutions when overlaying beam(pair)bkg!-->
+    <!--processor name="VXDPlanarDigiProcessor_DBDVXD"/-->
+    <!--processor name="VXDPlanarDigiProcessor_CMOSVXD1"/-->
+    <processor name="VXDPlanarDigiProcessor_CMOSVXD5"/>
+    
+
+    <processor name="SITPlanarDigiProcessor"/>
+    
+    <processor name="FTDPixelPlanarDigiProcessor"/>
+    <processor name="FTDStripPlanarDigiProcessor"/>
+    <processor name="FTDDDSpacePointBuilder" />
+    
+    <processor name="SETPlanarDigiProcessor"/>
+    <processor name="SETDDSpacePointBuilder" />
+    
+    <processor name="MyTPCDigiProcessor"/>
+    
+    <!-- ========== the new C++ tracking =============== -->
+    
+    <processor name="MyClupatraProcessor" />
+    
+    <!-- ========== central silicon tracking =============== -->
+    <!-- ========== standard DBD version =============== -->
+    <processor name="MySiliconTracking_MarlinTrk"/>  
+    <!-- ========== mini-vectors - make sure you use matching digitizer! =============== -->
+    <!--processor name="MyCellsAutomatonMV_UseSIT"/-->
+
+    <!-- need further investigation about the mini-vector tracking -->
+    <!-- <processor name="MyCellsAutomatonMV"/> -->
+    <!-- <processor name="MyExtrToSIT"/> -->
+
+    <!-- ========== FPCCD - make sure you use matching digitizer! =============== -->
+    <!--processor name="MyFPCCDSiliconTracking_MarlinTrk"/-->  
+
+    <processor name="MyForwardTracking"/><!--create fwd tracks in parallel -->
+    <processor name="MyTrackSubsetProcessor" /><!-- combine Silicon and Forward Tracking -->
+    <processor name="MyFullLDCTracking_MarlinTrk"/>
+
+    <!-- ========== dE/dx   ================= -->
+    <processor name="MyCompute_dEdxProcessor"/> 
+    
+    <!-- ========== the track cheater   ================= -->
+    <!-- XXXprocessor name="MyTruthTracker"/ -->
+    
+    <!-- ========== the post tracking patrec   ================= -->
+    
+    <processor name="MyV0Finder"/>
+    <processor name="MyKinkFinder"/>
+    
+    <!-- ========== calorimeter digitization and PFA ======= -->
+
+    <!-- merge ECal collections from even and odd layers first -->
+    <processor name="MergeCollectionsEcalBarrelHits" />
+    <processor name="MergeCollectionsEcalEndcapHits" />
+
+    <!-- Realistic digitisation for Ecal -->
+    <processor name="MyEcalBarrelDigi"/>
+    <processor name="MyEcalBarrelReco"/>
+    <processor name="MyEcalBarrelGapFiller"/>
+    
+    <processor name="MyEcalEndcapDigi"/>
+    <processor name="MyEcalEndcapReco"/>
+    <processor name="MyEcalEndcapGapFiller"/>
+    
+    <processor name="MyEcalRingDigi"/>
+    <processor name="MyEcalRingReco"/>
+    
+    <!-- Realistic digitisation for Hcal -->
+    <processor name="MyHcalBarrelDigi"/>
+    <processor name="MyHcalBarrelReco"/>
+    
+    <processor name="MyHcalEndcapDigi"/>
+    <processor name="MyHcalEndcapReco"/>
+    
+    <processor name="MyHcalRingDigi"/>
+    <processor name="MyHcalRingReco"/>
+    
+    <!-- Digitisation for the rests -->
+    <processor name="MySimpleBCalDigi"/>
+    <processor name="MySimpleLCalDigi"/>
+    <processor name="MySimpleLHCalDigi"/>
+    <processor name="MySimpleMuonDigi"/>
+    <processor name="MyDDMarlinPandora"/>
+
+    <!-- ========== covanriance matrix for charged PFOs  ======= -->
+    <!-- ========== should be done by MarlinPandora eventually ======= -->
+    <processor name="MyAdd4MomCovMatrixCharged"/>
+
+    <!-- ========== cluster position and direction w/ covariance; covariance matrix for neutral PFOs  ======= -->
+    <processor name="MyAddClusterProperties"/>
+
+    <!-- ========== BeamCal ======= -->
+    <!-- <processor name="MyBeamCalClusterReco"/> -->
+
+    <!-- ========== cluster position and direction w/ covariance; covariance matrix for neutral BeamCal PFOs  ======= -->
+    <!--processor name="BCalAddClusterProperties"/-->
+
+    <!-- ========== Shower Profiles   ================= -->
+    <processor name="MyComputeShowerShapesProcessor"/>    
+
+    <!-- ========== GammaGammaCandidateFinder   ================= -->
+
+    <processor name="MyPi0Finder"/>
+    <processor name="MyEtaFinder"/> 
+    <processor name="MyEtaPrimeFinder"/>  
+
+
+    <processor name="MyGammaGammaSolutionFinder"/> 
+    <processor name="MyDistilledPFOCreator"/> 
+
+    <!-- ========== particle ID ============================ -->
+    <processor name="MyLikelihoodPID" />
+
+    <!-- ========== full and DST output ==================== -->
+    <processor name="MyRecoMCTruthLinker"/> 
+    
+    <!-- ========== vertex finder ========================== -->
+    <processor name="VertexFinder"/>
+    
+    <processor name="MyLCIOOutputProcessor"/>
+    <processor name="DSTOutput"/>
+
+    <!-- =========== Pfo Analysis ======================== -->
+    <processor name="MyPfoAnalysis"/>
+
+  </execute>
+
+  <global>
+    <parameter name="LCIOInputFiles">
+      bbudsc_3evt.slcio
+    </parameter>
+    <parameter name="GearXMLFile" value="gear_ILD_o1_v05_dd4hep.xml"/>
+    <parameter name="MaxRecordNumber" value="0"/>
+    <parameter name="SkipNEvents" value="0"/>
+    <parameter name="SupressCheck" value="false"/>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+
+  <processor name="MyLCIOOutputProcessor" type="LCIOOutputProcessor">
+    <!--   standard output: full reconstruction keep all collections -->
+    <parameter name="LCIOOutputFile" type="string" >
+      ./bbudsc_3evt_REC.slcio
+    </parameter>
+    <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
+    <!--parameter name="SplitFileSizekB" type="int" value="1992294"/-->
+  </processor>
+
+  <processor name="InitDD4hep" type="InitializeDD4hep">
+    <!--InitializeDD4hep reads a compact xml file and initializes the DD4hep::LCDD object-->
+    <!--Name of the DD4hep compact xml file to load-->
+    <parameter name="DD4hepXMLFile" type="string"> $lcgeo_DIR/ILD/compact/ILD_o1_v05/ILD_o1_v05.xml </parameter>
+  </processor>
+  
+
+  <processor name="MySplitCollectionByLayer" type="SplitCollectionByLayer">
+    <!--split a hit collection based on the layer number of the hits -->
+    <!--Name of the input collection with hits-->
+    <parameter name="InputCollection" type="string">FTDCollection </parameter>
+    <!--Name of the output collection with start and end layer number-->
+    <parameter name="OutputCollections" type="StringVec">FTD_PIXELCollection 0 1 FTD_STRIPCollection 2 6  </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+  </processor>
+
+  <processor name="DSTOutput" type="LCIOOutputProcessor">
+    <!--   
+       DST output: drop all hits, skim MCParticles and keep final Tracks, Clusters, Vertices and  ReconstructedParticles 
+      -->
+    <parameter name="LCIOOutputFile" type="string" >
+      ./bbudsc_3evt_DST.slcio 
+    </parameter>
+    <parameter name="DropCollectionTypes" type="StringVec"> 
+      MCParticle 
+      SimTrackerHit 
+      SimCalorimeterHit
+      TrackerHit 
+      TrackerHitPlane 
+      CalorimeterHit 
+      LCRelation
+      Track 
+      LCFloatVec      
+    </parameter>
+    <parameter name="FullSubsetCollections" type="StringVec" value="MCParticlesSkimmed"/>
+    <parameter name="KeepCollectionNames" type="StringVec"> 
+      MCParticlesSkimmed 
+      MarlinTrkTracks
+      MCTruthMarlinTrkTracksLink
+      MarlinTrkTracksMCTruthLink
+      RecoMCTruthLink
+    </parameter>
+    <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
+    <!--parameter name="SplitFileSizekB" type="int" value="1992294"/-->
+  </processor>
+  
+  <processor name="MyStatusmonitor" type="Statusmonitor">
+    <!--Statusmonitor prints out information on running Marlin Job: Prints number of runs run and current number of the event. Counting is sequential and not the run or event ID.-->
+    <!--Print the event number every N events-->
+    <parameter name="HowOften" type="int">1 </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">MESSAGE </parameter> -->
+  </processor>
+  
+  <processor name="MyAIDAProcessor" type="AIDAProcessor">
+    <!--Processor that handles AIDA files. Creates on directory per processor.  Processors only need to create and fill the histograms, clouds and tuples. Needs to be the first ActiveProcessor-->
+    <!-- compression of output file 0: false >0: true (default) -->
+    <parameter name="Compress" type="int" value="1"/>
+    <!-- filename without extension-->
+    <parameter name="FileName" type="string" value="bbudsc_3evt_stdreco"/>
+    <!-- type of output file xml (default) or root ( only OpenScientist)-->
+    <parameter name="FileType" type="string" value="root "/>
+  </processor>
+
+
+  <processor name="BgOverlay" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Pairs of collection to be merged-->
+    <parameter name="CollectionMap" type="StringVec">
+      BeamCalCollection                     BeamCalCollection                     
+      EcalBarrelCollection                  EcalBarrelCollection           
+      EcalEndcapsCollection                 EcalEndcapsCollection           
+      EcalEndcapRingCollection              EcalEndcapRingCollection              
+      FTDCollection                         FTDCollection                   
+      HcalBarrelRegCollection               HcalBarrelRegCollection               
+      HcalEndcapRingCollection              HcalEndcapRingCollection             
+      HcalEndcapsCollection                 HcalEndcapsCollection                 
+      LumiCalCollection                     LumiCalCollection  
+      LHCalCollection                       LHCalCollection
+      MCParticle                            MCParticle                            
+      YokeBarrelCollection                  YokeBarrelCollection                  
+      YokeEndcapsCollection                 YokeEndcapsCollection                  
+      SETCollection                         SETCollection                         
+      SITCollection                         SITCollection                         
+      TPCCollection                         TPCCollection                         
+      VXDCollection                         VXDCollection                         
+    </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> 
+      /nfs/dust/ilc/group/ild/DD4hep_data/SIM/bkg/aa_lowpt/v01-19-01.E0500-TDR_ws.Paaddhad.Gwhizard-1.95.eB.pB.I37580.01_ILD_l1_v01_SIM.slcio
+    </parameter>
+    <!--Overlay each event with this number of background events. (default 0)-->
+    <parameter name="NumberOverlayEvents" type="int"> 0 </parameter>
+
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string"> DEBUG5 </parameter-->
+
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double">4.1 </parameter>
+    <!--Overlay each event with the content of one run.-->
+    <parameter name="runOverlay" type="bool">false </parameter>
+
+    <!--Maximum number of events to skip between overlayd events (choosen from flat intervall [0,NSkipEventsRandom] )-->
+    <parameter name="NSkipEventsRandom" type="int">0</parameter>
+
+  </processor>
+
+
+  <processor name="VXDPlanarDigiProcessor_DBDVXD" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> VXD </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float"> 0.0028 0.006 0.004 0.004 0.004 0.004 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float"> 0.0028 0.006 0.004 0.004 0.004 0.004  </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">VXDCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">VXDTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">VXDTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+  <processor name="VXDPlanarDigiProcessor_CMOSVXD5" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> VXD </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float"> 0.003 0.003 0.003 0.003 0.003 0.003 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float"> 0.003 0.003 0.003 0.003 0.003 0.003  </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">VXDCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">VXDTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">VXDTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+  <processor name="VXDPlanarDigiProcessor_CMOSVXD1" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> VXD </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float"> 0.0028 0.006 0.004 0.01 0.004 0.01 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float"> 0.0028 0.006 0.004 0.01 0.004 0.01  </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">VXDCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">VXDTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">VXDTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+  
+
+  <processor name="SITPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> SIT </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool"> false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float">0.007 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float">0.007 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">SITCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">SITTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">SITTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+
+  <processor name="FTDPixelPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> FTD </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float">0.003 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float">0.003 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit"> FTD_PIXELCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">FTDPixelTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">FTDPixelTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+
+  <processor name="FTDStripPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> FTD </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">true </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float">0.007 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float">0.0 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">FTD_STRIPCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">FTDStripTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">FTDStripTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+  
+  <processor name="SETPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> SET </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">true </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float">0.007 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float">0 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">SETCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">SETTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">SETTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+
+  <processor name="MyTPCDigiProcessor" type="DDTPCDigiProcessor">
+    <!--Produces TPC TrackerHit collection from SimTrackerHit collection, smeared in RPhi and Z. A search is made for adjacent hits on a pad row, if they are closer in z and r-phi than the steering parameters _doubleHitResRPhi (default value 2.0 mm) and _doubleHitResZ (default value 5.0 mm) they are considered to overlap. Clusters of hits smaller than _maxMerge (default value 3) are merged into a single tracker hit, with the position given as the average poision of the hits in phi and in z. Clusters which have _maxMerge hits or more are determined to be identifiable as multiple hits, and are not added to the tracker hit collection. This of course means that good hits caught up in a cluster of background hits will be lossed.-->
+
+    <!--R-Phi Diffusion Coefficent in TPC-->
+    <parameter name="DiffusionCoeffRPhi" type="float">0.025 </parameter>
+    <!--Z Diffusion Coefficent in TPC-->
+    <parameter name="DiffusionCoeffZ" type="float">0.08 </parameter>
+    <!--Defines the minimum distance for two seperable hits in RPhi-->
+    <parameter name="DoubleHitResolutionRPhi" type="float">2 </parameter>
+    <!--Defines the minimum distance for two seperable hits in Z-->
+    <parameter name="DoubleHitResolutionZ" type="float">5 </parameter>
+    <!--Defines spatial slice in RP-->
+    <parameter name="HitSortingBinningRPhi" type="float">2 </parameter>
+    <!--Defines spatial slice in Z-->
+    <parameter name="HitSortingBinningZ" type="float">5 </parameter>
+    <!--Defines the maximum number of adjacent hits which can be merged-->
+    <parameter name="MaxClusterSizeForMerge" type="int">3 </parameter>
+    <!--Number of Effective electrons per pad in TPC-->
+    <parameter name="N_eff" type="int">22 </parameter>
+    <!--Pad Phi Resolution constant in TPC-->
+    <parameter name="PointResolutionPadPhi" type="float">0.9 </parameter>
+    <!--R-Phi Resolution constant in TPC-->
+    <parameter name="PointResolutionRPhi" type="float">0.05 </parameter>
+    <!--TPC Z Resolution Coefficent independent of diffusion-->
+    <parameter name="PointResolutionZ" type="float">0.4 </parameter>
+    <!--whether or not to use hits without proper cell ID (pad row)-->
+    <parameter name="RejectCellID0" type="int">1 </parameter>
+    <!--Name of the LowPt SimTrackerHit collection Produced by Mokka TPC Driver TPC0X-->
+    <parameter name="TPCLowPtCollectionName" type="string" lcioInType="SimTrackerHit">TPCLowPtCollection </parameter>
+    <!--Name of the default pad-row based SimTrackerHit collection-->
+    <parameter name="TPCPadRowHitCollectionName" type="string" lcioInType="SimTrackerHit">TPCCollection </parameter>
+    <!--Name of the additional space point collection which provides additional guide hits between pad row centers.-->
+    <parameter name="TPCSpacePointCollectionName" type="string" lcioInType="SimTrackerHit">TPCSpacePointCollection </parameter>
+    <!--Name of the Output TrackerHit collection-->
+    <parameter name="TPCTrackerHitsCol" type="string" lcioOutType="TrackerHit"> TPCTrackerHits </parameter>
+    <!--Name of the Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">TPCTrackerHitRelations </parameter>
+
+    <!--Gap size in mm of the gaps between the endplace modules in Phi-->
+    <parameter name="TPCEndPlateModuleGapPhi" type="float"> 1. </parameter>
+    <!--Gap size in mm of the gaps between the endplace modules in R-->
+    <parameter name="TPCEndPlateModuleGapR" type="float">1. </parameter>
+    <!--Number of modules in the rings of the TPC endplate-->
+    <parameter name="TPCEndPlateModuleNumbers" type="IntVec">14 18 23 28 32 37 42 46  </parameter>
+    <!--Phi0s of modules in the rings of the TPC endplate-->
+    <parameter name="TPCEndPlateModulePhi0s" type="FloatVec">
+      0  0.17453292519943298  0.030350516853376176  0.2108457469509264  0.11998920441304516  0.1600004647682326  0.02051011203843622  0.062176216344090166
+    </parameter>
+
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string"> MESSAGE </parameter-->
+  </processor>
+
+
+  <processor name="MyClupatraProcessor" type="ClupatraProcessor">
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest </parameter>
+
+    <!--ClupatraProcessor : nearest neighbour clustering seeded pattern recognition-->
+    <!--the maximum chi2-distance for which a hit is considered for merging -->
+    <parameter name="Chi2Cut" type="float">100 </parameter>
+    <!--optionally create some debug collection with intermediate track segments and used and unused hits-->
+    <parameter name="CreateDebugCollections" type="bool"> false true  </parameter>
+    <!--Cut for distance between hits in mm-->
+    <parameter name="DistanceCut" type="float">40 </parameter>
+    <!--allowed fraction of hits in same pad row per track-->
+    <parameter name="DuplicatePadRowFraction" type="float">0.1 </parameter>
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool"> true </parameter>
+    <!--the maximum delta Chi2 for which a hit is added to a track segement-->
+    <parameter name="MaxDeltaChi2" type="float">35 </parameter>
+    <!--the maximum number of layers without finding a hit before hit search search is stopped -->
+    <parameter name="MaxStepWithoutHit" type="int">6 </parameter>
+    <!--minimum fraction of layers that have a given multiplicity, when forcing a cluster into sub clusters-->
+    <parameter name="MinLayerFractionWithMultiplicity" type="float">0.5 </parameter>
+    <!--minimum number of layers that have a given multiplicity, when forcing a cluster into sub clusters-->
+    <parameter name="MinLayerNumberWithMultiplicity" type="int">3 </parameter>
+    <!--minimum number of hits per cluster-->
+    <parameter name="MinimumClusterSize" type="int">6 </parameter>
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool">false true </parameter>
+    <!--number of bins in z over total length of TPC - hits from different z bins are nver merged-->
+    <parameter name="NumberOfZBins" type="int">150 </parameter>
+    <!--Name of the output collection-->
+    <parameter name="OutputCollection" type="string" lcioOutType="Track">ClupatraTracks </parameter>
+    <!--Name of the output collection that has the individual track segments-->
+    <parameter name="SegmentCollectionName" type="string" lcioOutType="Track">ClupatraTrackSegments </parameter>
+
+    <!--number of pad rows used in initial seed clustering-->
+    <parameter name="PadRowRange" type="int">15 </parameter>
+    
+    <!--try to pick up hits from Si-trackers-->
+    <parameter name="pickUpSiHits" type="bool">false </parameter>
+    <!--name of the SIT hit collections - used to extend TPC tracks if (pickUpSiHits==true)-->
+    <parameter name="SITHitCollection" type="string">SITTrackerHits </parameter>
+    <!--name of the VXD hit collections - used to extend TPC tracks if (pickUpSiHits==true)-->
+    <parameter name="VXDHitCollection" type="string">VXDTrackerHits </parameter>
+    
+    <!--Smooth All Mesurement Sites in Fit-->
+    <parameter name="SmoothOn" type="bool">false </parameter>
+    <!--Name of the tpc hit input collections-->
+    <parameter name="TPCHitCollection" type="string" lcioInType="TrackerHit">TPCTrackerHits </parameter>
+    
+    <!--maximum radial distance [mm] from outer field cage of last hit, such that the track is considered to end at the end -->
+    <parameter name="TrackEndsOuterCentralDist" type="float">25 </parameter>
+    <!--maximum distance in z [mm] from endplate of last hit, such that the track is considered to end at the end -->
+    <parameter name="TrackEndsOuterForwardDist" type="float">40 </parameter>
+    <!--minimum curvature omega of a track segment for being considered a curler-->
+    <parameter name="TrackIsCurlerOmega" type="float">0.001 </parameter>
+    <!--maximum radial distance [mm] from inner field cage of first hit, such that the track is considered to start at the beginning -->
+    <parameter name="TrackStartsInnerDist" type="float">25 </parameter>
+
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">MESSAGE DEBUG5 </parameter-->
+  </processor>
+
+
+
+  <processor name="MySiliconTracking_MarlinTrk" type="SiliconTracking_MarlinTrk">
+    <!--Pattern recognition in silicon trackers-->
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest </parameter>
+    <!--Angle Cut For Merging-->
+    <parameter name="AngleCutForMerging" type="float">0.1 </parameter>
+    <!--Check for Delta rays hits in hit-to-track assignment-->
+    <parameter name="CheckForDelta" type="int">1 </parameter>
+    <!--Chi2 Fit Cut-->
+    <parameter name="Chi2FitCut" type="float">120 </parameter>
+    <!--Chi2 Prefit Cut-->
+    <parameter name="Chi2PrefitCut" type="float">1e+10 </parameter>
+    <!--Chi2WRphiQuartet-->
+    <parameter name="Chi2WRphiQuartet" type="float">1 </parameter>
+    <!--Chi2WRphiSeptet-->
+    <parameter name="Chi2WRphiSeptet" type="float">1 </parameter>
+    <!--Chi2WRphiTriplet-->
+    <parameter name="Chi2WRphiTriplet" type="float">1 </parameter>
+    <!--Chi2WZQuartet-->
+    <parameter name="Chi2WZQuartet" type="float">0.5 </parameter>
+    <!--Chi2WZSeptet-->
+    <parameter name="Chi2WZSeptet" type="float">0.5 </parameter>
+    <!--Chi2WZTriplet-->
+    <parameter name="Chi2WZTriplet" type="float">0.5 </parameter>
+    <!--cut on D0 for tracks-->
+    <parameter name="CutOnD0" type="float">100 </parameter>
+    <!--cut on Pt-->
+    <parameter name="CutOnPt" type="float">0.05 </parameter>
+    <!--cut on Z0 for tracks-->
+    <parameter name="CutOnZ0" type="float">100 </parameter>
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool"> true </parameter>
+    <!--FTD Pixel Hit Collection Name-->
+    <parameter name="FTDPixelHitCollectionName" type="string" lcioInType="TrackerHitPlane"> FTDPixelTrackerHits </parameter>
+    <!--FTD FTDSpacePoint Collection Name-->
+    <parameter name="FTDSpacePointCollection" type="string" lcioInType="TrackerHit"> FTDSpacePoints </parameter>
+    <!--Fast attachment-->
+    <parameter name="FastAttachment" type="int">0 </parameter>
+    <!--Value used for the initial d0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorD0" type="float">1e+06 </parameter>
+    <!--Value used for the initial omega variance of the trackfit-->
+    <parameter name="InitialTrackErrorOmega" type="float">0.0001 </parameter>
+    <!--Value used for the initial phi0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorPhi0" type="float">100 </parameter>
+    <!--Value used for the initial tanL variance of the trackfit-->
+    <parameter name="InitialTrackErrorTanL" type="float">100 </parameter>
+    <!--Value used for the initial z0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorZ0" type="float">1e+06 </parameter>
+    <!--Combinations of Hits in Layers-->
+    <parameter name="LayerCombinations" type="IntVec"> 
+      8 6 5  8 6 4  8 6 3  8 6 2
+      8 5 3  8 5 2  8 4 3  8 4 2  
+      6 5 3  6 5 2  6 4 3  6 4 2 
+      6 3 1  6 3 0  6 2 1  6 2 0 
+      5 3 1  5 3 0  5 2 1  5 2 0
+      4 3 1  4 3 0  4 2 1  4 2 0    
+    </parameter>
+    <!--Combinations of Hits in FTD-->
+    <parameter name="LayerCombinationsFTD" type="IntVec"> 
+      13 11  9    13 11 8    13 10 9    13 10 8
+      12 11  9    12 11 8    12 10 9    12 10 8
+      11  9  7    11  9 6    11  8 7    11  8 6 
+      10  9  7    10  9 6    10  8 7    10  8 6
+      9  7  5     9  7 4     9  6 5     9  6 4
+      8  7  5     8  7 4     8  6 5     8  6 4
+      7  5  3     7  5 2     7  4 3     7  4 2
+      6  5  3     6  5 2     6  4 3     6  4 2
+      5  3  1     5  3 0     5  2 1     5  2 0
+      4  3  1     4  3 0     4  2 1     4  2 0
+    </parameter>
+    <!--Maximum Chi-squared value allowed when assigning a hit to a track-->
+    <parameter name="MaxChi2PerHit" type="double">100 </parameter>
+    <!--Maximal number of hits allowed in one theta-phi sector in VXD/SIT and FTD-->
+    <parameter name="MaxHitsPerSector" type="int">100 </parameter>
+    <!--MinDistCutAttach-->
+    <parameter name="MinDistCutAttach" type="float">2.5 </parameter>
+    <!--Minimal distance of track hit to the delta electron hit-->
+    <parameter name="MinDistToDelta" type="float">0.25 </parameter>
+    <!--MinLayerToAttach-->
+    <parameter name="MinLayerToAttach" type="int">-1 </parameter>
+    <!--minimal hits-->
+    <parameter name="MinimalHits" type="int">3 </parameter>
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
+    <!--Number of divisions in Phi-->
+    <parameter name="NDivisionsInPhi" type="int"> 80 </parameter>
+    <!--Number of divisions in Phi for FTD-->
+    <parameter name="NDivisionsInPhiFTD" type="int"> 30 </parameter>
+    <!--Number of divisions in Theta-->
+    <parameter name="NDivisionsInTheta" type="int"> 80 </parameter>
+    <!--Maximal number of hits for which a track with n hits is better than one with n-1hits. (defaut 5)-->
+    <parameter name="NHitsChi2" type="int">5 </parameter>
+    <!--Run MarlinTrk Diagnostics. MarlinTrk must be compiled with MARLINTRK_DIAGNOSTICS_ON defined-->
+    <parameter name="RunMarlinTrkDiagnostics" type="bool">false </parameter>
+    <!--SIT Hit Collection Name-->
+    <parameter name="SITHitCollectionName" type="string" lcioInType="TrackerHit"> SITTrackerHits</parameter>
+    <!--Silicon track Collection Name-->
+    <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracks </parameter>
+    <!--Smooth All Mesurement Sites in Fit-->
+    <parameter name="SmoothOn" type="bool"> false </parameter>
+    <!--Use SIT-->
+    <parameter name="UseSIT" type="int">1 </parameter>
+    <!--UseEventDisplay-->
+    <parameter name="UseEventDisplay" type="bool"> false </parameter>
+    <!--VTX Hit Collection Name-->
+    <parameter name="VTXHitCollectionName" type="string" lcioInType="TrackerHitPlane">VXDTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+
+  <processor name="MyTrackSubsetProcessor" type="TrackSubsetProcessor">
+    <!--TrackSubsetProcessor takes tracks from multiple sources and outputs them (or modified versions, or a subset of them) as one track collection.-->
+    <!--Remove short tracks from the list that have a longer track sharing the same hits-->
+    <parameter name="RemoveShortTracks" type="bool">true </parameter>
+
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest </parameter>
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool">true </parameter>
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool">true </parameter>
+    <!--The parameter omega for the HNN. Controls the influence of the quality indicator.-->
+    <parameter name="Omega" type="double">0.75 </parameter>
+    <!--Smooth All Measurement Sites in Fit-->
+    <parameter name="SmoothOn" type="bool">false </parameter>
+    <!--A vector of the input track collections-->
+    <parameter name="TrackInputCollections" type="StringVec">ForwardTracks SiTracks  </parameter>
+    <!--Name of the output track collection-->
+    <parameter name="TrackOutputCollection" type="string" lcioOutType="Track">SubsetTracks </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+
+
+  <!--###########  mini-vector tracking #################################    -->
+
+  <processor name="MyCellsAutomatonMV_UseSIT" type="DDCellsAutomatonMV">
+    <!--ForwardTracking reconstructs tracks through the FTDs-->
+    <!--Name of the Cellular Automaton Tracking output collection-->
+    <parameter name="CATrackCollection" type="string" lcioOutType="Track"> SiTracks </parameter>
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool">true </parameter>
+    <!--Number of divisions in Phi-->
+    <parameter name="NDivisionsInPhi" type="int"> 160 </parameter>
+    <!--Number of divisions in Theta-->
+    <parameter name="NDivisionsInTheta" type="int"> 80 </parameter>
+    <!--Number of divisions in Phi in  order to create mini-vectors-->
+    <parameter name="NDivisionsInPhiMV" type="int"> 80 </parameter>
+    <!--Number of divisions in Theta  in  order to create mini-vectors-->
+    <parameter name="NDivisionsInThetaMV" type="int"> 80 </parameter>
+    <!--VXD Hit Collections-->
+    <parameter name="VTXHitCollectionName" type="StringVec"> VXDTrackerHits </parameter>
+    <!--SIT Hit Collections-->
+    <parameter name="SITHitCollectionName" type="StringVec"> SITTrackerHits </parameter>
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool">true </parameter>
+    <!--Smooth All Measurement Sites in Fit-->
+    <parameter name="SmoothOn" type="bool">false </parameter>
+    <!--Cut on minimum PT-->
+    <parameter name="PTCut" type="double"> 0.0 </parameter>
+    <!--Use SIT-->
+    <parameter name="UseSIT" type="int"> 1 </parameter>
+    <!--The chi2 probability value below which tracks will be cut-->
+    <parameter name="Chi2ProbCut" type="double">0.005 </parameter>
+    <!--the maximum chi2/Ndf that is allowed as result of a helix fit-->
+    <parameter name="HelixFitMax" type="double"> 100 </parameter>
+    <!--the maximum chi2/Ndf that is allowed as result of a Kalman fit-->
+    <parameter name="kalFitMax" type="double"> 10 </parameter>
+    <!--The minimum number of hits to create a track-->
+    <parameter name="HitsPerTrackMin" type="int"> 2 </parameter>
+    <!--Maximal number of hits for which a track with n hits is better than one with n-1hits-->
+    <parameter name="NHitsChi2" type="int"> 6 </parameter>
+    <!--The method used to find the best non overlapping subset of tracks. Available are: SubsetHopfieldNN and SubsetSimple or NoSelection-->
+    <parameter name="BestSubsetFinder" type="string"> SubsetSimple </parameter>
+    <!--Whether when adding hits to a track only the track with highest quality should be further processed-->
+    <!--parameter name="TakeBestVersionOfTrack" type="bool">true </parameter-->
+    <!--If the automaton has more connections than this it will be redone with the next parameters-->
+    <parameter name="MaxConnectionsAutomaton" type="int"> 10000000 </parameter>
+    <!--Maximal number of hits allowed on a sector-->
+    <parameter name="MaxHitsPerSector" type="int">1000 </parameter>
+    <!--The maximum distance between two hits in adjacent layers in order to form a minivector-->
+    <parameter name="MaxDistance" type="double"> 5.0 </parameter>
+    <!--The difference in polar angle (in degrees)  between two hits in adjacent layers in order to form a minivector-->
+    <parameter name="MVHitsThetaDifference" type="double"> 0.1 </parameter>
+    <!--The difference in polar angle (in degrees)  between two hits in the INNER layer in order to form a minivector-->
+    <parameter name="MVHitsThetaDifferenceInner" type="double"> 0.1 </parameter>
+    <!--The maximum step between layers-->
+    <parameter name="StepMax" type="int"> 4 </parameter>
+    <!--The last layer that can be connected directly with the IP-->
+    <parameter name="LastLayerToIP" type="int"> 4 </parameter>
+    
+    <parameter name="Crit2_3DAngle_MV_min" type="float"> 0.0 </parameter>
+    <parameter name="Crit2_3DAngle_MV_max" type="float"> 15.0 </parameter>
+    <parameter name="Crit2_DeltaPhi_MV_min" type="float"> 0.0 </parameter>
+    <parameter name="Crit2_DeltaPhi_MV_max" type="float"> 15.0 </parameter>
+    <parameter name="Crit2_DeltaPhi_MV_InnLayer_min" type="float"> 0.0 </parameter>
+    <parameter name="Crit2_DeltaPhi_MV_InnLayer_max" type="float"> 5.0 </parameter>
+    <parameter name="Crit2_DeltaTheta_MV_min" type="float"> 0.0 </parameter>
+    <parameter name="Crit2_DeltaTheta_MV_max" type="float"> 1.5 </parameter>
+    <parameter name="Crit3_NoZigZag_MV_min" type="float"> -1.0 </parameter>
+    <parameter name="Crit3_NoZigZag_MV_max" type="float"> 1.0 </parameter>
+    <parameter name="Crit3_PT_MV_min" type="float"> 0.35 </parameter>
+    <parameter name="Crit3_PT_MV_max" type="float"> 999999 </parameter>   
+    <parameter name="Criteria" type="StringVec">
+      Crit2_DeltaPhi_MV
+      Crit2_DeltaTheta_MV
+      Crit3_NoZigZag_MV
+    </parameter>
+    
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+    
+  </processor> 
+
+
+  <!--###########  mini-vector tracking + ExtrToSIT #################################    -->
+
+  <processor name="MyCellsAutomatonMV" type="DDCellsAutomatonMV">
+    <!--ForwardTracking reconstructs tracks through the FTDs-->
+    
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest </parameter>
+    
+    <!--Name of the Cellular Automaton Tracking output collection-->
+    <parameter name="CATrackCollection" type="string" lcioOutType="Track"> CATracks </parameter>
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool">true </parameter>
+    <!--Number of divisions in Phi-->
+    <parameter name="NDivisionsInPhi" type="int"> 160 </parameter>
+    <!--Number of divisions in Theta-->
+    <parameter name="NDivisionsInTheta" type="int"> 80 </parameter>
+    <!--Number of divisions in Phi in  order to create mini-vectors-->
+    <parameter name="NDivisionsInPhiMV" type="int"> 80 </parameter>
+    <!--Number of divisions in Theta  in  order to create mini-vectors-->
+    <parameter name="NDivisionsInThetaMV" type="int"> 80 </parameter>
+    <!--VXD Hit Collections-->
+    <parameter name="VTXHitCollectionName" type="StringVec"> VXDTrackerHits </parameter>
+    <!--SIT Hit Collections-->
+    <parameter name="SITHitCollectionName" type="StringVec"> SITTrackerHits </parameter>
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool">true </parameter>
+    <!--Smooth All Measurement Sites in Fit-->
+    <parameter name="SmoothOn" type="bool">true </parameter>
+    <!--Cut on minimum PT-->
+    <parameter name="PTCut" type="double"> 0.0 </parameter>
+    <!--Use SIT-->
+    <parameter name="UseSIT" type="int"> 0 </parameter>
+    <!--Make a hit at IP-->
+    <parameter name="IPhit" type="int"> 1 </parameter>
+    <!--The chi2 probability value below which tracks will be cut-->
+    <parameter name="Chi2ProbCut" type="double">0.005 </parameter>
+    <!--the maximum chi2/Ndf that is allowed as result of a helix fit-->
+    <parameter name="HelixFitMax" type="double"> 100 </parameter>
+    <!--the maximum chi2/Ndf that is allowed as result of a Kalman fit-->
+    <parameter name="kalFitMax" type="double"> 10 </parameter>
+    <!--The minimum number of hits to create a track-->
+    <parameter name="HitsPerTrackMin" type="int"> 2 </parameter>
+    <!--Maximal number of hits for which a track with n hits is better than one with n-1hits-->
+    <parameter name="NHitsChi2" type="int"> 6 </parameter>
+    <!-- TrackState to use for initialization of the fit: -1: refit from hits [default], 1: AtIP, 2: AtFirstHit, 3: AtLastHit, 4:AtCalo -->
+    <parameter name="InitialTrackState" type="int"> 1</parameter>
+    <!--Fit direction: -1: backward [default], +1: forward-->
+    <parameter name="FitDirection" type="int"> +1 </parameter>
+    <!--The method used to find the best non overlapping subset of tracks. Available are: SubsetHopfieldNN and SubsetSimple or NoSelection-->
+    <parameter name="BestSubsetFinder" type="string"> SubsetSimple </parameter>
+    <!--Whether when adding hits to a track only the track with highest quality should be further processed-->
+    <!--parameter name="TakeBestVersionOfTrack" type="bool">true </parameter-->
+    <!--If the automaton has more connections than this it will be redone with the next parameters-->
+    <parameter name="MaxConnectionsAutomaton" type="int"> 10000000 </parameter>
+    <!--Maximal number of hits allowed on a sector-->
+    <parameter name="MaxHitsPerSector" type="int">1000 </parameter>
+    <!--The maximum distance between two hits in adjacent layers in order to form a minivector-->
+    <parameter name="MaxDistance" type="double"> 5.0 </parameter>
+    <!--The difference in polar angle (in degrees)  between two hits in adjacent layers in order to form a minivector-->
+    <parameter name="MVHitsThetaDifference" type="double"> 0.1 </parameter>
+    <!--The difference in polar angle (in degrees)  between two hits in the INNER layer in order to form a minivector-->
+    <parameter name="MVHitsThetaDifferenceInner" type="double"> 0.1 </parameter>
+    <!--The difference in polar angle (in degrees)  between two hits in SIT-->
+    <parameter name="MVHitsThetaDifferenceSIT" type="double"> 3.5 </parameter>
+    <!--The maximum step between layers-->
+    <parameter name="StepMax" type="int"> 4 </parameter>
+    <!--The last layer that can be connected directly with the IP-->
+    <parameter name="LastLayerToIP" type="int"> 4 </parameter>
+   
+    <parameter name="Crit2_3DAngle_MV_min" type="float"> 0.0 </parameter>
+    <parameter name="Crit2_3DAngle_MV_max" type="float"> 15.0 </parameter>
+    <parameter name="Crit2_DeltaPhi_MV_min" type="float"> 0.0 </parameter>
+    <parameter name="Crit2_DeltaPhi_MV_max" type="float"> 150.0 </parameter>
+    <parameter name="Crit2_DeltaPhi_MV_InnLayer_min" type="float"> 0.0 </parameter>
+    <parameter name="Crit2_DeltaPhi_MV_InnLayer_max" type="float"> 5.0 </parameter>
+    <parameter name="Crit2_DeltaTheta_MV_min" type="float"> 0.0 </parameter>
+    <parameter name="Crit2_DeltaTheta_MV_max" type="float"> 150.0 </parameter>
+    <parameter name="Crit3_NoZigZag_MV_min" type="float"> -1.0 </parameter>
+    <parameter name="Crit3_NoZigZag_MV_max" type="float"> 1.0 </parameter>
+    <parameter name="Crit3_PT_MV_min" type="float"> 0.1 </parameter>
+    <parameter name="Crit3_PT_MV_max" type="float"> 999999 </parameter>   
+    <parameter name="Criteria" type="StringVec">
+      Crit2_DeltaPhi_MV
+      Crit2_DeltaTheta_MV
+      Crit3_PT_MV
+    </parameter>
+   
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+   
+  </processor> 
+
+  <processor name="MyExtrToSIT" type="ExtrToSIT">
+    <!--ExtrToSIT refits an input track collection, producing a new collection of tracks.-->
+
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest </parameter>
+
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool">true </parameter>
+    <!--Name of the input track collection-->
+    <!--parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> MarlinTrkTracks </parameter-->
+    <!--parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> TruthTracks </parameter-->
+    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> CATracks </parameter>
+    <!--Name of the SITTrackerHit collection-->
+    <!--parameter name="digitisedSITHits" type="string" lcioInType="TrackerHit"> SITTrackerHits </parameter-->
+    <parameter name="digitisedSITHits" type="string" lcioInType="TrackerHit"> SITTrackerHits </parameter>
+    <!--Name of the VTXTrackerHit collection-->
+    <parameter name="digitisedVXDHits" type="string" lcioInType="TrackerHit"> VXDTrackerHits </parameter>
+    <!--Name of the MCParticle-Track Relations collection for input tracks-->
+    <!--parameter name="InputTrackRelCollection" type="string" lcioInType="LCRelation"> MarlinTrkTracksMCP </parameter-->
+    <!--parameter name="InputTrackRelCollection" type="string" lcioInType="LCRelation"> TruthTracksMCP </parameter-->
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool">true </parameter>
+    <!--maximum allowable chi2 increment when moving from one site to another-->
+    <parameter name="Max_Chi2_Incr" type="double"> 100 </parameter>
+    <!--minimum acceptable no of hits for the TPC tracks-->
+    <parameter name="TPCHitsCut" type="int"> 100 </parameter>
+    <!--Which layer should the seed be propagated to-->
+    <parameter name="PropagateToLayer" type="double"> 0 </parameter>
+    <!--maximum acceptable chi2/ndof for the TPC tracks-->
+    <parameter name="Chi2NDoFCut" type="int"> 100 </parameter>
+    <!--maximum acceptable Z0 at IP-->
+    <parameter name="Z0Cut" type="float"> 25 </parameter>
+    <!--maximum acceptable D0 at IP-->
+    <parameter name="D0Cut" type="float"> 2500000 </parameter>
+    <!--times d0(Z0) acceptable from track extrapolation point-->
+    <parameter name="SearchSigma" type="double"> 10.0 </parameter>
+    <!--The method used to find the best non overlapping subset of tracks. Available are: SubsetHopfieldNN and SubsetSimple or NoSelection-->
+    <parameter name="BestSubsetFinder" type="string"> SubsetSimple </parameter>
+    <!--Name of the output track collection-->
+    <parameter name="OutputTrackCollectionName" type="string" lcioOutType="Track"> SiTracks </parameter>
+    <!--Name of the MCParticle-Track Relations collection for output tracks-->
+    <parameter name="OutputTrackRelCollection" type="string" lcioOutType="LCRelation"> SiTracksMCP </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+  </processor>
+
+
+  <!--###########  FPCCD tracking #################################    -->
+
+  <processor name="MyFPCCDSiliconTracking_MarlinTrk" type="FPCCDSiliconTracking_MarlinTrk">
+    <!--Each ladder's FPCCD Pixel size(unit:mm)-->
+    <parameter name="PixelSizeVec" type="float"> 0.016 0.064 0.040 0.040 0.040 </parameter>
+    <!--AttachRemainingHitsForVXD-->
+    <parameter name="AttachRemainingHitsForVXD" type="int"> 2 </parameter>
+    <!--parameter name="LayerCombinations" type="IntVec"> 
+    5 3 1  5 3 0  5 2 1  5 2 0
+    4 3 1  4 3 0  4 2 1  4 2 0    
+    </parameter-->
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+  </processor>
+
+
+
+  
+  <processor name="MyFullLDCTracking_MarlinTrk" type="FullLDCTracking_MarlinTrk">
+    <!--Performs full tracking in ILD detector-->
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest </parameter>
+
+    <!--Cut on Opening Angle for forced merging of Si and TPC segments-->
+    <parameter name="AngleCutForForcedMerging" type="float">0.05 </parameter>
+    <!--Cut on Opening Angle for merging Si and TPC segments-->
+    <parameter name="AngleCutForMerging" type="float">0.1 </parameter>
+    <!--Assign ETD Hits-->
+    <parameter name="AssignETDHits" type="int">0 </parameter>
+    <!--Assign left over FTD hits-->
+    <parameter name="AssignFTDHits" type="int">1 </parameter>
+    <!--Assign SET Hits-->
+    <parameter name="AssignSETHits" type="int"> 1 </parameter>
+    <!--Assign left over SIT hits-->
+    <parameter name="AssignSITHits" type="int">1 </parameter>
+    <!--Assign left over TPC hits-->
+    <parameter name="AssignTPCHits" type="int">0 </parameter>
+    <!--Assign left over VTX hits-->
+    <parameter name="AssignVTXHits" type="int">1 </parameter>
+    <!--Cut on fit Chi2-->
+    <parameter name="Chi2FitCut" type="float">100 </parameter>
+    <!--Cut on the number of the Si hits for tracks with no TPC hits-->
+    <parameter name="CutOnSiHits" type="int">4 </parameter>
+    <!--Cut on the number of the TPC hits for tracks with no Si hits-->
+    <parameter name="CutOnTPCHits" type="int">10 </parameter>
+    <!--Cut on the track parameter D0-->
+    <parameter name="CutOnTrackD0" type="float">500 </parameter>
+    <!--Cut on the track parameter Z0-->
+    <parameter name="CutOnTrackZ0" type="float">500 </parameter>
+    <!--Cut on D0 difference for forced merging of Si and TPC segments-->
+    <parameter name="D0CutForForcedMerging" type="float">50 </parameter>
+    <!--Cut on D0 difference for merging of Si and TPC segments-->
+    <parameter name="D0CutForMerging" type="float">500 </parameter>
+    <!--Cut on D0 difference for merging TPC segments-->
+    <parameter name="D0CutToMergeTPCSegments" type="float">100 </parameter>
+    <!--Activate debugging?-->
+    <parameter name="Debug" type="int">0 </parameter>
+    <!--Cut on dP/P difference for merging TPC segments-->
+    <parameter name="DeltaPCutToMergeTPCSegments" type="float">0.1 </parameter>
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool"> true </parameter>
+    <!--Cut on distance between track and FTD hits-->
+    <parameter name="FTDHitToTrackDistance" type="float">2 </parameter>
+    <!--FTD Pixel Hit Collection Name-->
+    <parameter name="FTDPixelHitCollectionName" type="string" lcioInType="TrackerHitPlane"> FTDPixelTrackerHits </parameter>
+    <!--FTD FTDSpacePoint Collection Name-->
+    <parameter name="FTDSpacePointCollection" type="string" lcioInType="TrackerHit"> FTDSpacePoints </parameter>
+    <!--Forbid overlap in Z for combining TPC segments with tracks having Si hits-->
+    <parameter name="ForbidOverlapInZComb" type="int">0 </parameter>
+    <!--Forbid overlap in Z for the merged TPC segments-->
+    <parameter name="ForbidOverlapInZTPC" type="int">0 </parameter>
+    <!--Force merging of Si and TPC segments?-->
+    <parameter name="ForceSiTPCMerging" type="int">0 </parameter>
+    <!--Force merging of TPC Segments?-->
+    <parameter name="ForceTPCSegmentsMerging" type="int"> 0 </parameter>
+    <!--Value used for the initial d0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorD0" type="float">1e+06 </parameter>
+    <!--Value used for the initial omega variance of the trackfit-->
+    <parameter name="InitialTrackErrorOmega" type="float">0.0001 </parameter>
+    <!--Value used for the initial phi0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorPhi0" type="float">100 </parameter>
+    <!--Value used for the initial tanL variance of the trackfit-->
+    <parameter name="InitialTrackErrorTanL" type="float">100 </parameter>
+    <!--Value used for the initial z0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorZ0" type="float">1e+06 </parameter>
+    <!--LDC track collection name-->
+    <parameter name="LDCTrackCollection" type="string" lcioOutType="Track">MarlinTrkTracks </parameter>
+    <!--Maximum Chi-squared value allowed when assigning a hit to a track-->
+    <parameter name="MaxChi2PerHit" type="double"> 200 </parameter>
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
+    <!--number of hits for outward extrapolation-->
+    <parameter name="NHitsExtrapolation" type="int">35 </parameter>
+    <!--Cut on Omega difference for forced merging of Si and TPC segments-->
+    <parameter name="OmegaCutForForcedMerging" type="float">0.15 </parameter>
+    <!--Cut on Omega difference for merging Si and TPC segments-->
+    <parameter name="OmegaCutForMerging" type="float">0.25 </parameter>
+    <!--Cut on Pt of tracks for merging TPC segments-->
+    <parameter name="PtCutToMergeTPCSegments" type="float">1.2 </parameter>
+    <!--Run MarlinTrk Diagnostics. MarlinTrk must be compiled with MARLINTRK_DIAGNOSTICS_ON defined-->
+    <parameter name="RunMarlinTrkDiagnostics" type="bool">false </parameter>
+    <!--SET Hit Collection Name-->
+    <parameter name="SETHitCollection" type="string" lcioInType="TrackerHit">SETSpacePoints </parameter>
+    <!--Cut on distance between track and SET hits-->
+    <parameter name="SETHitToTrackDistance" type="float">50 </parameter>
+    <!--SIT Hit Collection Name-->
+    <parameter name="SITHitCollection" type="string" lcioInType="TrackerHit"> SITTrackerHits </parameter>
+    <!--Cut on distance between track and SIT hits-->
+    <parameter name="SITHitToTrackDistance" type="float">2 </parameter>
+    <!--Si Track Collection-->
+    <parameter name="SiTracks" type="string" lcioInType="Track">SubsetTracks </parameter>
+    <!--Si Track to Collection-->
+    <parameter name="SiTracksMCPRelColl" type="string" lcioInType="LCRelation">SubsetTracksMCTruthLink </parameter>
+    <!--Smooth All Mesurement Sites in Fit-->
+    <parameter name="SmoothOn" type="bool">true </parameter>
+    <!--TPC Hit Collection Name-->
+    <parameter name="TPCHitCollection" type="string" lcioInType="TrackerHit">TPCTrackerHits </parameter>
+    <!--Cut on distance between track and TPC hits-->
+    <parameter name="TPCHitToTrackDistance" type="float">15 </parameter>
+    <!--TPC Track Collection-->
+    <parameter name="TPCTracks" type="string" lcioInType="Track">ClupatraTracks </parameter>
+    <!--TPC Track to MCP Relation Collection Name-->
+    <parameter name="TPCTracksMCPRelColl" type="string" lcioInType="LCRelation">TPCTracksMCTruthLink </parameter>
+    <!--VTX Hit Collection Name-->
+    <parameter name="VTXHitCollection" type="string" lcioInType="TrackerHit">VXDTrackerHits </parameter>
+    <!--Cut on distance between track and VTX hits-->
+    <parameter name="VTXHitToTrackDistance" type="float">1.5 </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    <!--Cut on Z0 difference for forced merging of Si and TPC segments-->
+    <parameter name="Z0CutForForcedMerging" type="float">200 </parameter>
+    <!--Cut on Z0 difference for merging of Si and TPC segments-->
+    <parameter name="Z0CutForMerging" type="float">1000 </parameter>
+    <!--Cut on Z0 difference for merging TPC segments-->
+    <parameter name="Z0CutToMergeTPCSegments" type="float">5000 </parameter>
+    <!--Cut on cos theta between the two momentum vectors when considering merger of high Pt tracks-->
+    <parameter name="cosThetaCutHighPtMerge" type="float">0.99 </parameter>
+    <!--cut on cos theta between the two momentum vectors when considering merger of high Pt tracks for softer dp/p cut-->
+    <parameter name="cosThetaCutSoftHighPtMerge" type="float">0.998 </parameter>
+    <!--cut on 3D distance between hit and helix extrapolation when considering merger of high Pt tracks-->
+    <parameter name="hitDistanceCutHighPtMerge" type="float">25 </parameter>
+    <!--cut on maximum fraction of outliers when considering merger of high Pt tracks-->
+    <parameter name="maxFractionOfOutliersCutHighPtMerge" type="float">0.95 </parameter>
+    <!--cut for max 3D distance between any hit and helix extrapolation when considering merger of high Pt tracks-->
+    <parameter name="maxHitDistanceCutHighPtMerge" type="float">50 </parameter>
+    <!--cut on dp/p when considering merger of high Pt tracks-->
+    <parameter name="momDiffCutHighPtMerge" type="float">0.01 </parameter>
+    <!--softer cut on dp/p when considering merger of high Pt tracks-->
+    <parameter name="momDiffCutSoftHighPtMerge" type="float">0.25 </parameter>
+  </processor>
+
+
+  <!--  dedx calculation processor -->
+  <processor name="MyCompute_dEdxProcessor" type="Compute_dEdxProcessor">
+    <!--Energy Loss Error for TPC-->
+    <parameter name="EnergyLossErrorTPC" type="float">0.05 </parameter>
+    <!--LDC Track collectoin name-->
+    <parameter name="LDCTrackCollection" type="string"> MarlinTrkTracks </parameter>
+  </processor>
+
+
+
+  <processor name="MyForwardTracking" type="ForwardTracking">
+    <!--ForwardTracking reconstructs tracks through the FTDs-->
+
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest </parameter>
+
+    <!--Name of the Forward Tracking output collection-->
+    <parameter name="ForwardTrackCollection" type="string" lcioOutType="Track">ForwardTracks </parameter>
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool">true </parameter>
+    <!--FTD Hit Collections-->
+    <parameter name="FTDHitCollections" type="StringVec">FTDPixelTrackerHits FTDSpacePoints</parameter>
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool">true </parameter>
+    <!--Smooth All Measurement Sites in Fit-->
+    <parameter name="SmoothOn" type="bool">false </parameter>
+    <!--The chi2 probability value below which tracks will be cut-->
+    <parameter name="Chi2ProbCut" type="double">0.0 </parameter>
+    <!--the maximum chi2/Ndf that is allowed as result of a helix fit-->
+    <parameter name="HelixFitMax" type="double">500 </parameter>
+    <!--The maximum distance of overlapping hits-->
+    <parameter name="OverlappingHitsDistMax" type="double">3.5 </parameter>
+    <!--The minimum number of hits to create a track-->
+    <parameter name="HitsPerTrackMin" type="int">3 </parameter>
+    <!--The method used to find the best non overlapping subset of tracks. Available are: SubsetHopfieldNN and SubsetSimple-->
+    <parameter name="BestSubsetFinder" type="string">SubsetSimple </parameter>
+    <!--Whether when adding hits to a track only the track with highest quality should be further processed-->
+    <parameter name="TakeBestVersionOfTrack" type="bool">true </parameter>
+    <!--If the automaton has more connections than this it will be redone with the next parameters-->
+    <parameter name="MaxConnectionsAutomaton" type="int">100000 </parameter>
+    <!--Maximal number of hits allowed on a sector-->
+    <parameter name="MaxHitsPerSector" type="int">1000 </parameter>
+    
+    <parameter name="Crit2_DeltaPhi_min" type="float">0 0</parameter>
+    <parameter name="Crit2_DeltaPhi_max" type="float">30 0.8</parameter>
+    <parameter name="Crit2_DeltaRho_min" type="float">20</parameter>
+    <parameter name="Crit2_DeltaRho_max" type="float">150</parameter>
+    <parameter name="Crit2_RZRatio_min" type="float">1.002</parameter>
+    <parameter name="Crit2_RZRatio_max" type="float">1.08</parameter>
+    <parameter name="Crit2_StraightTrackRatio_min" type="float">0.9 0.99</parameter>
+    <parameter name="Crit2_StraightTrackRatio_max" type="float">1.02 1.01</parameter>
+    
+    <parameter name="Crit3_3DAngle_min" type="float">0 0</parameter>
+    <parameter name="Crit3_3DAngle_max" type="float">10 0.35</parameter>
+    <parameter name="Crit3_ChangeRZRatio_min" type="float">0.995 0.999</parameter>
+    <parameter name="Crit3_ChangeRZRatio_max" type="float">1.015 1.001</parameter>
+    <parameter name="Crit3_IPCircleDist_min" type="float">0 0</parameter>
+    <parameter name="Crit3_IPCircleDist_max" type="float">20 1.5</parameter>
+    <parameter name="Crit3_PT_min" type="float">0.1</parameter>
+    <parameter name="Crit3_PT_max" type="float">99999999</parameter>
+    
+    <parameter name="Crit4_3DAngleChange_min" type="float">0.8 0.99</parameter>
+    <parameter name="Crit4_3DAngleChange_max" type="float">1.3 1.01</parameter>
+    <parameter name="Crit4_DistToExtrapolation_min" type="float">0 0</parameter>
+    <parameter name="Crit4_DistToExtrapolation_max" type="float">1.0 0.05</parameter>
+    
+    <parameter name="Criteria" type="StringVec">
+      Crit2_DeltaPhi
+      Crit2_DeltaRho
+      Crit2_RZRatio
+      Crit2_StraightTrackRatio
+      
+      Crit3_3DAngle
+      Crit3_ChangeRZRatio
+      Crit3_IPCircleDist
+      Crit3_PT
+      
+      Crit4_DistToExtrapolation
+      Crit4_3DAngleChange
+    </parameter>
+    
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    
+  </processor> 
+
+  <processor name="MyTruthTracker" type="TruthTracker">
+    <!--Creates Track Collection from MC Truth. Can handle composite spacepoints as long as they consist of two TrackerHits-->
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest </parameter>
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool">true </parameter>
+    <!--Fit the Tracks with MarlinTrk, otherwise take track parameters from MCParticle-->
+    <parameter name="FitTracksWithMarlinTrk" type="bool">true </parameter>
+    <!--Transverse Momentum Threshold MC particles which will produce tracks GeV-->
+    <parameter name="MCpThreshold" type="float">0.1 </parameter>
+    <!--Use MultipleScattering in Fit-->
+    <parameter name="MultipleScatteringOn" type="bool">true </parameter>
+    <!--Name of the output track collection-->
+
+    <!-- FIXME: for testing write out 'cheated' MarlinTrkTracks -->
+    <parameter name="OutputTrackCollectionName" type="string" lcioOutType="Track"> TruthTracks </parameter>
+
+    <!--Name of the MCParticle-Track Relations collection for output tracks-->
+    <parameter name="OutputTrackRelCollection" type="string" lcioOutType="LCRelation">TruthTracksMCP </parameter>
+    <!--Smooth All Mesurement Sites in Fit-->
+    <parameter name="SmoothOn" type="bool"> true </parameter>
+    <!--Name of the tracker hit input collections-->
+    <parameter name="TrackerHitsInputCollections" type="StringVec" lcioInType="TrackerHit">VXDTrackerHits SITTrackerHits FTDPixelTrackerHits FTDSpacePoints TPCTrackerHits SETSpacePoints  </parameter>
+    <!--Name of the lcrelation collections, that link the TrackerHits to their SimTrackerHits. Have to be in same order as TrackerHitsInputCollections!!!-->
+    <parameter name="TrackerHitsRelInputCollections" type="StringVec" lcioInType="LCRelation">VXDTrackerHitRelations SITTrackerHitRelations FTDPixelTrackerHitRelations FTDSpacePointRelations TPCTrackerHitRelations SETSpacePointRelations  </parameter>
+    <!--Fit the Tracks with MarlinTrk using iterative approach. If 3 consecutive hits fail to be included then the  current fit is written out and a new fit started. Use instead of FitTracksWithMarlinTrk.-->
+    <parameter name="UseIterativeFitting" type="bool">  true </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+  
+
+  <!--########## KinkFinder ###################################### -->
+
+  <processor name="MyKinkFinder" type="KinkFinder">
+    <parameter name="DebugPrinting" type="int"> 0</parameter>
+    <parameter name="TrackCollection" type="string"> MarlinTrkTracks</parameter>
+  </processor>
+
+  <!--######  MyV0Finder ##########################################-->
+  <processor name="MyV0Finder" type="V0Finder">
+    <parameter name="TrackCollection" type="string"> MarlinTrkTracks</parameter>
+    <parameter name="MassRangeGamma"  type="float">  0.01 </parameter>
+    <parameter name="MassRangeK0S"    type="float">  0.02 </parameter>
+    <parameter name="MassRangeL0"     type="float">  0.02 </parameter>
+  </processor>
+
+  <!--######  My RealisticCaloDigi ################################-->
+  <!--#### ECAL ####-->
+
+  <processor name="MergeCollectionsEcalBarrelHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalBarrelSiHitsEven ECalBarrelSiHitsOdd </parameter>
+    <parameter name="OutputCollection" type="string"> EcalBarrelCollection </parameter>
+  </processor>
+
+  <processor name="MergeCollectionsEcalEndcapHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalEndcapSiHitsEven ECalEndcapSiHitsOdd </parameter>
+    <parameter name="OutputCollection" type="string"> EcalEndcapsCollection </parameter>
+  </processor>
+
+  <!--### the Ecal barrel ###-->
+  <!--digitisation -->
+  <processor name="MyEcalBarrelDigi" type="RealisticCaloDigiSilicon">
+    <parameter name="inputHitCollections"> EcalBarrelCollection </parameter>
+    <parameter name="outputHitCollections"> EcalBarrelCollectionDigi </parameter>
+    <parameter name="outputRelationCollections"> EcalBarrelRelationsSimDigi </parameter>
+    <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="timingCut"> 1  </parameter>
+    <parameter name="calibration_mip"> 0.0001525 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!-- reconstruction -->
+  <processor name="MyEcalBarrelReco" type="RealisticCaloRecoSilicon">
+    <parameter name="inputHitCollections"> EcalBarrelCollectionDigi </parameter>
+    <parameter name="inputRelationCollections"> EcalBarrelRelationsSimDigi </parameter>
+    <parameter name="outputHitCollections"> EcalBarrelCollectionRec </parameter>
+    <parameter name="outputRelationCollections"> EcalBarrelRelationsSimRec </parameter>
+    <parameter name="calibration_layergroups"> 20 11 </parameter>
+    <parameter name="calibration_factorsMipGev"> 0.00637432 0.01274865 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!-- gap filling -->
+  <processor name="MyEcalBarrelGapFiller" type="BruteForceEcalGapFiller">
+    <parameter name="inputHitCollection"> EcalBarrelCollectionRec </parameter>
+    <parameter name="outputHitCollection"> EcalBarrelCollectionGapHits </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+    <parameter name="CellIDModuleString"> module </parameter>
+    <parameter name="CellIDStaveString"> stave </parameter>
+    <parameter name="expectedInterModuleDistance"> 7.0 </parameter>
+  </processor>
+  <!--### the Ecal endcaps ###-->
+  <!-- digitisation -->
+  <processor name="MyEcalEndcapDigi" type="RealisticCaloDigiSilicon">
+    <parameter name="inputHitCollections"> EcalEndcapsCollection </parameter>
+    <parameter name="outputHitCollections"> EcalEndcapsCollectionDigi </parameter>
+    <parameter name="outputRelationCollections"> EcalEndcapsRelationsSimDigi </parameter>
+    <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="timingCut"> 1  </parameter>
+    <parameter name="calibration_mip"> 0.0001525 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!-- reconstruction -->
+  <processor name="MyEcalEndcapReco" type="RealisticCaloRecoSilicon">
+    <parameter name="inputHitCollections"> EcalEndcapsCollectionDigi </parameter>
+    <parameter name="inputRelationCollections"> EcalEndcapsRelationsSimDigi </parameter>
+    <parameter name="outputHitCollections"> EcalEndcapsCollectionRec </parameter>
+    <parameter name="outputRelationCollections"> EcalEndcapsRelationsSimRec </parameter>
+    <parameter name="calibration_layergroups"> 20 11 </parameter>
+    <parameter name="calibration_factorsMipGev"> 0.00637432 0.01274865 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!-- gap filling -->
+  <processor name="MyEcalEndcapGapFiller" type="BruteForceEcalGapFiller">
+    <parameter name="inputHitCollection"> EcalEndcapsCollectionRec </parameter>
+    <parameter name="outputHitCollection"> EcalEndcapsCollectionGapHits </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+    <parameter name="CellIDModuleString"> module </parameter>
+    <parameter name="CellIDStaveString"> stave </parameter>
+    <parameter name="expectedInterModuleDistance"> 7.0 </parameter>
+  </processor>
+  <!--### the Ecal endcap rings ###-->
+  <!-- digitisation -->
+  <processor name="MyEcalRingDigi" type="RealisticCaloDigiSilicon">
+    <parameter name="inputHitCollections"> EcalEndcapRingCollection </parameter>
+    <parameter name="outputHitCollections"> EcalEndcapRingCollectionDigi </parameter>
+    <parameter name="outputRelationCollections"> EcalEndcapRingRelationsSimDigi </parameter>
+    <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="timingCut"> 1  </parameter>
+    <parameter name="calibration_mip"> 0.0001525 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!-- reconstruction -->
+  <processor name="MyEcalRingReco" type="RealisticCaloRecoSilicon">
+    <parameter name="inputHitCollections"> EcalEndcapRingCollectionDigi </parameter>
+    <parameter name="inputRelationCollections"> EcalEndcapRingRelationsSimDigi </parameter>
+    <parameter name="outputHitCollections"> EcalEndcapRingCollectionRec </parameter>
+    <parameter name="outputRelationCollections"> EcalEndcapRingRelationsSimRec </parameter>
+    <parameter name="calibration_layergroups"> 20 11 </parameter>
+    <parameter name="calibration_factorsMipGev"> 0.00637432 0.01274865 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+
+  <!--#### HCAL ####-->
+  <!--### the Hcal barrel ###-->
+  <!-- digitisation -->
+  <processor name="MyHcalBarrelDigi" type="RealisticCaloDigiScinPpd">
+    <parameter name="inputHitCollections"> HcalBarrelRegCollection </parameter>
+    <parameter name="outputHitCollections"> HcalBarrelCollectionDigi </parameter>
+    <parameter name="outputRelationCollections"> HcalBarrelRelationsSimDigi </parameter>
+    <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="thresholdUnit"> MIP </parameter>
+    <parameter name="timingCut"> 1  </parameter>
+    <!-- the ave energy deposition of a MIP in the scint -->
+    <parameter name="calibration_mip"> 0.0004925 </parameter>
+    <parameter name="ppd_mipPe"> 15 </parameter>
+    <parameter name="ppd_npix"> 2000 </parameter>
+    <parameter name="ppd_npix_uncert"> 0 </parameter>
+    <parameter name="ppd_pix_spread"> 0 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!-- reconstruction -->
+  <processor name="MyHcalBarrelReco" type="RealisticCaloRecoScinPpd">
+    <parameter name="inputHitCollections"> HcalBarrelCollectionDigi </parameter>
+    <parameter name="inputRelationCollections"> HcalBarrelRelationsSimDigi </parameter>
+    <parameter name="outputHitCollections"> HcalBarrelCollectionRec </parameter>
+    <parameter name="outputRelationCollections"> HcalBarrelRelationsSimRec </parameter>
+    <parameter name="ppd_mipPe"> 15 </parameter> 
+    <parameter name="ppd_npix"> 2000 </parameter> 
+    <parameter name="calibration_layergroups"> 100 </parameter>
+    <!-- factor to convert from MIP to GeV (including energy in absorber) -->
+    <parameter name="calibration_factorsMipGev"> 0.0246896 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!--### the Hcal endcaps ###-->
+  <!-- digitisation -->
+  <processor name="MyHcalEndcapDigi" type="RealisticCaloDigiScinPpd">
+    <parameter name="inputHitCollections"> HcalEndcapsCollection </parameter>
+    <parameter name="outputHitCollections"> HcalEndcapsCollectionDigi </parameter>
+    <parameter name="outputRelationCollections"> HcalEndcapsRelationsSimDigi </parameter>
+    <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="thresholdUnit"> MIP </parameter>
+    <parameter name="timingCut"> 1  </parameter>
+    <!-- the ave energy deposition of a MIP in the scint -->
+    <parameter name="calibration_mip"> 0.0004725 </parameter>
+    <parameter name="ppd_mipPe"> 15 </parameter>
+    <parameter name="ppd_npix"> 2000 </parameter>
+    <parameter name="ppd_npix_uncert"> 0 </parameter>
+    <parameter name="ppd_pix_spread"> 0 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!-- reconstruction -->
+  <processor name="MyHcalEndcapReco" type="RealisticCaloRecoScinPpd">
+    <parameter name="inputHitCollections"> HcalEndcapsCollectionDigi </parameter>
+    <parameter name="inputRelationCollections"> HcalEndcapsRelationsSimDigi </parameter>
+    <parameter name="outputHitCollections"> HcalEndcapsCollectionRec </parameter>
+    <parameter name="outputRelationCollections"> HcalEndcapsRelationsSimRec </parameter>
+    <parameter name="ppd_mipPe"> 15 </parameter> 
+    <parameter name="ppd_npix"> 2000 </parameter> 
+    <parameter name="calibration_layergroups"> 100 </parameter>
+    <!-- factor to convert from MIP to GeV (including energy in absorber) -->
+    <parameter name="calibration_factorsMipGev"> 0.0291279 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!--### the Hcal ring ###-->
+  <!-- digitisation -->
+  <processor name="MyHcalRingDigi" type="RealisticCaloDigiScinPpd">
+    <parameter name="inputHitCollections"> HcalEndcapRingCollection </parameter>
+    <parameter name="outputHitCollections"> HcalEndcapRingCollectionDigi </parameter>
+    <parameter name="outputRelationCollections"> HcalEndcapRingRelationsSimDigi </parameter>
+    <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="thresholdUnit"> MIP </parameter>
+    <parameter name="timingCut"> 1  </parameter>
+    <!-- the ave energy deposition of a MIP in the scint -->
+    <parameter name="calibration_mip"> 0.0004875  </parameter>
+    <parameter name="ppd_mipPe"> 15 </parameter>
+    <parameter name="ppd_npix"> 2000 </parameter>
+    <parameter name="ppd_npix_uncert"> 0 </parameter>
+    <parameter name="ppd_pix_spread"> 0 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <!-- reconstruction -->
+  <processor name="MyHcalRingReco" type="RealisticCaloRecoScinPpd">
+    <parameter name="inputHitCollections"> HcalEndcapRingCollectionDigi </parameter>
+    <parameter name="inputRelationCollections"> HcalEndcapRingRelationsSimDigi </parameter>
+    <parameter name="outputHitCollections"> HcalEndcapRingCollectionRec </parameter>
+    <parameter name="outputRelationCollections"> HcalEndcapRingRelationsSimRec </parameter>
+    <parameter name="ppd_mipPe"> 15 </parameter> 
+    <parameter name="ppd_npix"> 2000 </parameter> 
+    <parameter name="calibration_layergroups"> 100 </parameter>
+    <!-- factor to convert from MIP to GeV (including energy in absorber) -->
+    <parameter name="calibration_factorsMipGev"> 0.0347959 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  
+  <!--######  SimpleBCALDigi ##########################################-->
+
+  <processor name="MySimpleBCalDigi" type="SimpleFCalDigi">
+    <!--Performs simple digitization of sim calo hits...-->
+
+    <!--ID of calorimeter: lcal, fcal, bcal-->
+    <parameter name="CaloID" type="string">bcal </parameter>
+
+    <!--name of the part of the cellID that holds the layer-->
+    <parameter name="CellIDLayerString" type="string"> layer </parameter>
+
+    <!--Calibration coefficients for LCAL-->
+    <parameter name="CalibrFCAL" type="FloatVec">1.</parameter>
+    <!--LCAL Collection Names-->
+    <parameter name="FCALCollections" type="StringVec">BeamCalCollection</parameter>
+    <!--LCAL Collection of real Hits-->
+    <parameter name="FCALOutputCollection" type="string">BCAL</parameter>
+    <!--Threshold for LCAL Hits in GeV-->
+    <parameter name="FcalThreshold" type="float">1e-06 </parameter>
+    <!--MuonHit Relation Collection-->
+    <parameter name="RelationOutputCollection" type="string">RelationBCalHit </parameter>
+  </processor>
+
+
+  <!--######  SimpleLCalDigi ##########################################-->
+
+  <processor name="MySimpleLCalDigi" type="SimpleFCalDigi">
+    <!--Performs simple digitization of sim calo hits...-->
+
+    <!--ID of calorimeter: lcal, fcal, bcal-->
+    <parameter name="CaloID" type="string">lcal </parameter>
+
+    <!--name of the part of the cellID that holds the layer-->
+    <parameter name="CellIDLayerString" type="string"> layer </parameter>
+
+    <!--Calibration coefficients for LCAL-->
+    <parameter name="CalibrFCAL" type="FloatVec">89.0</parameter>
+    <!--LCAL Collection Names-->
+    <parameter name="FCALCollections" type="StringVec"> LumiCalCollection  </parameter>
+    <!--LCAL Collection of real Hits-->
+    <parameter name="FCALOutputCollection" type="string">LCAL </parameter>
+    <!--Threshold for LCALHits in GeV-->
+    <parameter name="FcalThreshold" type="float">0e-04 </parameter>
+    <!--LCALHit Relation Collection-->
+    <parameter name="RelationOutputCollection" type="string">RelationLcalHit </parameter>
+  </processor>
+  
+  <!--######  SimpleLHCALDigi ##########################################-->
+
+  <processor name="MySimpleLHCalDigi" type="SimpleFCalDigi">
+    <!--Performs simple digitization of sim calo hits...-->
+
+    <!--ID of calorimeter: lcal, fcal, bcal-->
+    <parameter name="CaloID" type="string">lhcal </parameter>
+
+    <!--name of the part of the cellID that holds the layer-->
+    <parameter name="CellIDLayerString" type="string"> layer </parameter>
+
+    <!--Calibration coefficients for LHCAL-->
+    <parameter name="CalibrFCAL" type="FloatVec">150</parameter>
+    <!--LHCAL Collection Names-->
+    <parameter name="FCALCollections" type="StringVec"> LHCalCollection</parameter>
+    <!--LHCAL Collection of real Hits-->
+    <parameter name="FCALOutputCollection" type="string">LHCAL </parameter>
+    <!--Threshold for LHCAL Hits in GeV-->
+    <parameter name="FcalThreshold" type="float">1e-06 </parameter>
+    <!--LHCALHit Relation Collection-->
+    <parameter name="RelationOutputCollection" type="string">RelationLHcalHit </parameter>
+  </processor>
+
+  <!--######  SimpleMuonDigi ##########################################-->
+
+  <processor name="MySimpleMuonDigi" type="SimpleMuonDigi">
+    <!--Performs simple digitization of sim calo hits...-->
+    
+    <!--name of the part of the cellID that holds the layer-->
+    <parameter name="CellIDLayerString" type="string"> layer </parameter>
+    
+    <!--Calibration coefficients for MUON-->
+    <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+    <!-- maximum hit energy for a MUON hit -->
+    <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
+    <!--MUON Collection Names-->
+    <parameter name="MUONCollections" type="StringVec">
+      YokeBarrelCollection YokeEndcapsCollection</parameter>
+    <!--MUON Collection of real Hits-->
+    <parameter name="MUONOutputCollection" type="string">MUON </parameter>
+    <!--Threshold for MUON Hits in GeV-->
+    <parameter name="MUONThreshold" type="float">1e-06 </parameter>
+    <!--MuonHit Relation Collection-->
+    <parameter name="RelationOutputCollection" type="string">RelationMuonHit </parameter>
+  </processor>
+
+  <!--########## MarlinPandora ###################################### -->
+
+  <!--
+     Calibration constants in MarlinPandora are determined using 100ns timing cuts in both the ECal
+     and HCal, realistic digitisation options in the ECal (Si) and HCal and a 1 GeV hadronic energy 
+     truncation for HCal cells (post digitisation).  Timing cuts and realistic digitisation options 
+     are specified in ILDCaloDigi and the hadronic energy truncation is specified in MarlinPandora. 
+     If either the detector model changes or the reconstruction parameters change you must recalibrate!
+    -->
+
+  <processor name="MyDDMarlinPandora" type="DDPandoraPFANewProcessor">
+    <!--Track cut on distance from BarrelTracker inner r to id whether track can form pfo-->
+    <parameter name="MaxBarrelTrackerInnerRDistance" type="float">105.0 </parameter>
+    <parameter name="PandoraSettingsXmlFile" type="String"> PandoraSettingsDefault.xml </parameter>
+    <!-- Collection names -->
+    <parameter name="TrackCollections" type="StringVec">MarlinTrkTracks</parameter>
+    <parameter name="ECalCaloHitCollections" type="StringVec">EcalBarrelCollectionRec EcalBarrelCollectionGapHits EcalEndcapsCollectionRec EcalEndcapsCollectionGapHits EcalEndcapRingCollectionRec</parameter>
+    <parameter name="HCalCaloHitCollections" type="StringVec">HcalBarrelCollectionRec HcalEndcapsCollectionRec HcalEndcapRingCollectionRec</parameter>
+    <parameter name="LCalCaloHitCollections" type="StringVec">LCAL</parameter>
+    <parameter name="LHCalCaloHitCollections" type="StringVec">LHCAL</parameter>
+    <parameter name="MuonCaloHitCollections" type="StringVec">MUON</parameter>
+    <parameter name="MCParticleCollections" type="StringVec">MCParticle</parameter>
+    <parameter name="RelCaloHitCollections" type="StringVec">EcalBarrelRelationsSimRec EcalEndcapsRelationsSimRec EcalEndcapRingRelationsSimRec HcalBarrelRelationsSimRec HcalEndcapsRelationsSimRec HcalEndcapRingRelationsSimRec RelationMuonHit</parameter>
+    <parameter name="RelTrackCollections" type="StringVec">MarlinTrkTracksMCP</parameter>
+    <parameter name="KinkVertexCollections" type="StringVec">KinkVertices</parameter>
+    <parameter name="ProngVertexCollections" type="StringVec">ProngVertices</parameter>
+    <parameter name="SplitVertexCollections" type="StringVec">SplitVertices</parameter>
+    <parameter name="V0VertexCollections" type="StringVec">V0Vertices</parameter>
+    <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
+    <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
+    <!-- Calibration constants -->
+    <parameter name="ECalToMipCalibration" type="float">156.88</parameter>
+    <parameter name="HCalToMipCalibration" type="float">40.4858</parameter>
+    <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
+    <parameter name="ECalMipThreshold" type="float">0.5</parameter>
+    <parameter name="HCalMipThreshold" type="float">0.3</parameter>
+    <parameter name="ECalToEMGeVCalibration" type="float">1.</parameter>
+    <parameter name="HCalToEMGeVCalibration" type="float">1.04898</parameter>
+    <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.21826</parameter>
+    <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.21826</parameter>
+    <parameter name="HCalToHadGeVCalibration" type="float">1.04898</parameter>
+    <parameter name="DigitalMuonHits" type="int">0</parameter>
+    <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter> 
+    <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
+
+    <!--Whether to calculate track states manually, rather than copy stored fitter values-->
+    <parameter name="UseOldTrackStateCalculation" type="int"> 0 1  </parameter> <!-- !!!FIXME, workaround for some missing TS AtCalo face - this should really be: 0 -->
+    <parameter name="NEventsToSkip" type="int">0</parameter>
+    <!--parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG0 </parameter-->
+    <!--The name of the Vertex Barrel detector-->
+    <parameter name="VertexBarrelDetectorName" type="string">VXD </parameter>
+    <!--Detector names of the Trackers in the Barrel starting from the innermost one-->
+    <parameter name="TrackerBarrelDetectorNames" type="StringVec">TPC</parameter>
+    <!--Detector names of the Trackers in the Endcap starting from the innermost one-->
+    <parameter name="TrackerEndcapDetectorNames" type="StringVec">FTD</parameter>
+    <parameter name="CoilName" type="string">Coil</parameter>
+    <parameter name="ECalBarrelDetectorName" type="string">EcalBarrel </parameter>
+    <parameter name="ECalEndcapDetectorName" type="string">EcalEndcap </parameter>
+    <parameter name="ECalOtherDetectorNames" type="StringVec">EcalPlug Lcal BeamCal  </parameter>
+    <parameter name="HCalEndcapDetectorName" type="string">HcalEndcap </parameter>
+    <parameter name="HCalBarrelDetectorName" type="string">HcalBarrel </parameter>
+    <parameter name="HCalOtherDetectorNames" type="StringVec">HcalRing LHcal </parameter>
+    <parameter name="MuonBarrelDetectorName" type="string">YokeBarrel </parameter>
+    <parameter name="MuonEndcapDetectorName" type="string">YokeEndcap </parameter>
+    <parameter name="MuonOtherDetectorNames" type="StringVec"></parameter>
+    <!--Decides whether to create gaps in the geometry (ILD-specific)-->
+    <!---SHOULD BE TRUE FOR ILD BUT INNER/OUTER SYMMETRIES ARE NOT COMPATIBLE -->
+    <parameter name="CreateGaps" type="bool">false</parameter>
+    <!--The name of the DDTrackCreator implementation-->
+    <parameter name="TrackCreatorName" type="string">DDTrackCreatorILD </parameter>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> SILENT </parameter>
+  </processor>
+
+
+  <!--################################################ -->
+  <processor name="MyBeamCalClusterReco" type="BeamCalClusterReco">
+    <!--BeamCalClusterReco takes a list of beamcal background files from the ReadBeamCalprocessor, adds NumberOfBX of them together and puts the signal hits from thelcio input file on top of that, and then clustering is attempted.-->
+    <!--Name of BeamCal Collection-->
+    <parameter name="BeamCalCollectionName" type="string" lcioInType="SimCalorimeterHit">BCAL </parameter>
+    <!--Flag to create the TEfficiency for fast tagging library-->
+    <parameter name="CreateEfficiencyFile" type="bool"> true </parameter>
+    <!--Energy in a Cluster to consider it an electron-->
+    <parameter name="ETCluster" type="FloatVec">0.5 0.5  </parameter>
+    <!--Energy in a Pad, after subtraction of background required to consider it for signal-->
+    <parameter name="ETPad" type="FloatVec"> 0.01 0.3  </parameter>
+    <!--The name of the rootFile which will contain the TEfficiency objects-->
+    <parameter name="EfficiencyFilename" type="string">TaggingEfficiency.root </parameter>
+    <!--Background simulation method-->
+    <parameter name="BackgroundMethod" type="string">Parametrised </parameter>
+    <!--Root Inputfile(s)-->
+    <parameter name="InputFileBackgrounds" type="StringVec">
+      BeamCal_bg_E500-TDR_ws.root
+    </parameter>
+    <!--Name of the MCParticle Collection-->
+    <parameter name="MCParticle Collection Name, only needed and used to estimate efficiencies" type="string" lcioInType="MCParticle">MCParticle </parameter>
+    <!--Minimum number of pads in a single tower to be considered for signal-->
+    <parameter name="MinimumTowerSize" type="int">6 </parameter>
+    <parameter name="LinearCalibrationFactor" type="double"> 72. </parameter>
+    <!--Number of Bunch Crossings of Background-->
+    <parameter name="NumberOfBX" type="int">1 </parameter>
+    <!--Number of Event that should be printed to PDF File-->
+    <parameter name="PrintThisEvent" type="int">1 </parameter>
+    <!--Name of the Reconstructed Cluster collection-->
+    <parameter name="RecoClusterCollectionname" type="string" lcioOutType="Cluster">BCalClusters </parameter>
+    <!--Name of the Reconstructed Particle collection-->
+    <parameter name="RecoParticleCollectionname" type="string" lcioOutType="ReconstructedParticle">BCalRecoParticle </parameter>
+    <!--If not using ConstPadCuts, each pad SigmaCut*variance is considered for clusters-->
+    <parameter name="SigmaCut" type="double">2 </parameter>
+    <!--Layer (inclusive) from which on we start looking for signal clusters-->
+    <parameter name="StartLookingInLayer" type="int">2 </parameter>
+    <!--Rings from which onwards the outside Thresholds are used-->
+    <parameter name="StartingRing" type="FloatVec">0 1  </parameter>
+    <!--Use the cuts for the pads specified in ETPad, if false, the variance in each pad is used times SigmaPad Factor-->
+    <parameter name="UseConstPadCuts" type="bool">False </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">WARNING </parameter>
+  </processor>
+
+  <!--################################################ -->
+  <processor name="MyBCalReco" type="BCalReco">
+    <!--Filling Histograms with deposited energy from beamstrahlung pairs in BeamCal-->
+    <!--Name of the Beamcal clusters collection-->
+    <parameter name="BCALClusterName" type="string" lcioOutType="Cluster">BCALClusters </parameter>
+    <!--Name of the Beamcal cluster to mc-particle relation collection-->
+    <parameter name="BCALMCTruthLinkName" type="string" lcioOutType="LCRelation">BCALMCTruthLink </parameter>
+    <!-- Name of input file for background energy density-->
+    <parameter name="BackgroundFilename" type="string">
+      bg_aver.sv01-14-p00.mILD_o1_v05.E1000-B1b_ws.PBeamstr-pairs.I210000.root
+    </parameter>
+    <!--Collection of SimCalorimeterHits in BeamCal-->
+    <parameter name="BeamCalHitCol" type="string">BCAL </parameter>
+    <!--Name of the MCParticle collection-->
+    <parameter name="CollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
+    <!-- Event Clusters Histgram X axis range [n] (10 by default)-->
+    <parameter name="EventClustersHistoRange" type="int">10 </parameter>
+    <!--Name of the Beamcal reconstructed particles collection-->
+    <parameter name="RecoPartCollectionName" type="string" lcioOutType="ReconstructedParticle">BCALParticles </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+  <!--################################################ -->
+
+  <processor name="MyPFOID" type="PFOID">
+    <!--Performs particle identification-->
+    <!--Debugging?-->
+    <parameter name="Debug" type="int">0 </parameter>
+    <!--Boundaries for energy binning-->
+    <parameter name="EnergyBoundaries" type="FloatVec">0 10 1e+07  </parameter>
+    <!--Name of files containing pdfs for charged particles-->
+    <parameter name="FilePDFName" type="StringVec">
+      pdf_charged_lt10.txt pdf_charged_ge10.txt
+    </parameter>
+    <!--Name of the PFO collection-->
+    <parameter name="RecoParticleCollection" type="string">PandoraPFOs</parameter>
+    <!--Name of files containing pdfs for neutral particles-->
+    <parameter name="neutralFilePDFName" type="StringVec">
+      pdf_neutral_lt10.txt pdf_neutral_ge10.txt
+    </parameter>
+  </processor>
+
+  <!--################################################ -->
+
+
+  <processor name="MyRecoMCTruthLinker" type="RecoMCTruthLinker">
+    <!--links RecontructedParticles to the MCParticle based on number of hits used-->
+    
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING0  </parameter> 
+    
+    <!--  Input collections: mcparticles, pfos, clusters and tracks 
+          PFOs already connect to tracks and clusters, so what we do in this processor is to connect
+          tracks and clusters to mcparticles ... 
+          The values given here are the defaults, so they don't really need to be
+          specified -->
+    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCParticle </parameter>
+    <!--Name of the ReconstructedParticles input collection-->
+    <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle"> PandoraPFOs </parameter>
+    <!--Name of the Cluster collection -->
+    <parameter name="ClusterCollection" type="string" lcioInType="Cluster"> PandoraClustersHack </parameter>
+    <!--Name of the Tracks input collection-->
+    <parameter name="TrackCollection" type="string" lcioInType="Track">MarlinTrkTracks </parameter>
+    
+    <!-- Don't change any of these hit related collections if you're not very sure you know what you are doing.
+         In any case, the ones listed here are the defaults, so they can be removed from
+         this steering -->
+    <!--  Simulated tracker hits (has the conection to MCParticles -->
+    <parameter name="SimTrackerHitCollections" type="StringVec" lcioInType="SimTrackerHit">
+      VXDCollection 
+      SITCollection 
+      FTD_PIXELCollection 
+      FTD_STRIPCollection 
+      TPCCollection 
+      SETCollection  
+    </parameter>
+    <!--  Connections from tracker hits (connected to tracks) to sim tracker hits (connects to MC particle) -->
+    <parameter name="TrackerHitsRelInputCollections" type="StringVec" lcioInType="LCRelation">
+      VXDTrackerHitRelations 
+      SITTrackerHitRelations
+      FTDPixelTrackerHitRelations 
+      FTDSpacePointRelations 
+      TPCTrackerHitRelations 
+      SETSpacePointRelations  
+    </parameter>
+    <!-- same for the calos: Simulated calo hits (has the connection to MCParticles) -->
+    <parameter name="SimCaloHitCollections" type="StringVec" lcioInType="SimCalorimeterHit">
+      BeamCalCollection
+      EcalBarrelCollection
+      EcalEndcapsCollection
+      EcalEndcapRingCollection
+      HcalBarrelRegCollection
+      HcalEndcapsCollection
+      HcalEndcapRingCollection
+      LHCalCollection
+      LumiCalCollection
+      YokeBarrelCollection
+      YokeEndcapsCollection
+    </parameter> 
+    <!-- Connections from calo hist (connected to clusters) tp sim calo hits  (connects to MC particle) -->
+    <parameter name="SimCalorimeterHitRelationNames" type="StringVec" lcioInType="LCRelation">
+      RelationCaloHit
+      RelationLHcalHit
+      RelationMuonHit
+      RelationLcalHit
+      RelationBCalHit
+    </parameter> 
+    
+    <!--PDG codes of particles of which the daughters will be kept in the skimmmed MCParticle collection-->
+    <parameter name="KeepDaughtersPDG" type="IntVec"> 22 111 310 13 211 321</parameter>
+    
+    <!--Names of the output collections -->
+    <!--Name of the skimmed MCParticle  output collection-->
+    <parameter name="MCParticlesSkimmedName" type="string" lcioOutType="MCParticle"> MCParticlesSkimmed </parameter>
+    
+    <!-- links between tracks or clusters and mcparticles. The two sets differ
+         in what the weight means. These four will only be output if the
+         name is given here in the steering -->
+    <parameter name="MCTruthTrackLinkName" type="string" lcioOutType="LCRelation"> MCTruthMarlinTrkTracksLink </parameter>  
+    <parameter name="TrackMCTruthLinkName" type="string" lcioOutType="LCRelation"> MarlinTrkTracksMCTruthLink </parameter>
+    <parameter name="MCTruthClusterLinkName" type="string" lcioOutType="LCRelation"> MCTruthClusterLink </parameter>
+    <parameter name="ClusterMCTruthLinkName" type="string" lcioOutType="LCRelation"> ClusterMCTruthLink </parameter>
+
+
+    <!-- Links PFO <-> MCParticles. Only RecoMCTruthLink is output by default,
+         to also get the reverse link, MCTruthRecoLinkName must be given here -->
+    <parameter name="RecoMCTruthLinkName" type="string" lcioOutType="LCRelation"> RecoMCTruthLink </parameter>
+    <parameter name="MCTruthRecoLinkName" type="string" lcioOutType="LCRelation"> MCTruthRecoLink </parameter>
+    <!-- set to true to get the weights in RecoMCTruthLink to include both weights to
+         tracks and clusters. False implies that only the true particle that
+         gives most contributions to the track of the PFO (charged PFOs), or
+         to the cluster (neutral ones) is linked to the PFO -->
+    <parameter name="FullRecoRelation" type="bool"> true </parameter>
+    
+    <!-- further options -->
+    <!--true: use relations for TrackerHits, false : use getRawHits -->
+    <parameter name="UseTrackerHitRelations" type="bool"> true </parameter>
+    <!--If Using Particle Gun Ignore Gen Stat-->
+    <parameter name="UsingParticleGun" type="bool"> false </parameter>
+  </processor>
+
+
+  <processor name="VertexFinder" type="LcfiplusProcessor">
+
+    <!-- run primary and secondary vertex finders -->
+    <parameter name="Algorithms" type="stringVec"> PrimaryVertexFinder BuildUpVertex </parameter>
+    <parameter name="ReadSubdetectorEnergies" type="int" value="1"/> <!-- true for ILD -->
+    <parameter name="UpdateVertexRPDaughters" type="int" value="1"/> <!-- false for non-updative PandoraPFOs -->
+    <parameter name="TrackHitOrdering" type="int" value="1"/> <!-- Track hit ordering: 0=ILD-LOI,SID-DBD, 1=ILD-DBD -->
+    <parameter name="PrintEventNumber" type="int" value="0"/> <!-- 0 for not printing event number, n for printing every n events -->
+
+    <!-- specify input collection names -->
+    <parameter name="PFOCollection" type="string" value="PandoraPFOs" />
+    <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertex" />
+    <parameter name="BuildUpVertexCollectionName" type="string" value="BuildUpVertex" />
+    <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="BuildUpVertex_V0" />
+
+    <!-- parameters for primary vertex finder -->
+    <parameter name="PrimaryVertexFinder.TrackMaxD0" type="double" value="20." />
+    <parameter name="PrimaryVertexFinder.TrackMaxZ0" type="double" value="20." />
+    <parameter name="PrimaryVertexFinder.TrackMinVtxFtdHits" type="int" value="1" />
+    <parameter name="PrimaryVertexFinder.Chi2Threshold" type="double" value="25." />
+
+    <!-- parameters for secondary vertex finder -->
+    <parameter name="BuildUpVertex.TrackMaxD0" type="double" value="10." />
+    <parameter name="BuildUpVertex.TrackMaxZ0" type="double" value="20." />
+    <parameter name="BuildUpVertex.TrackMinPt" type="double" value="0.1" />
+    <parameter name="BuildUpVertex.TrackMaxD0Err" type="double" value="0.1" />
+    <parameter name="BuildUpVertex.TrackMaxZ0Err" type="double" value="0.1" />
+    <parameter name="BuildUpVertex.TrackMinTpcHits" type="int" value="10000" />
+    <parameter name="BuildUpVertex.TrackMinFtdHits" type="int" value="10000" />
+    <parameter name="BuildUpVertex.TrackMinVxdHits" type="int" value="10000" />
+    <parameter name="BuildUpVertex.TrackMinVxdFtdHits" type="int" value="0" />
+    <parameter name="BuildUpVertex.PrimaryChi2Threshold" type="double" value="25." />
+    <parameter name="BuildUpVertex.SecondaryChi2Threshold" type="double" value="9." />
+    <parameter name="BuildUpVertex.MassThreshold" type="double" value="10." />
+    <parameter name="BuildUpVertex.MinDistFromIP" type="double" value="0.3" />
+    <parameter name="BuildUpVertex.MaxChi2ForDistOrder" type="double" value="1.0" />
+    <parameter name="BuildUpVertex.AssocIPTracks" type="int" value="1" />
+    <parameter name="BuildUpVertex.AssocIPTracksMinDist" type="double" value="0." />
+    <parameter name="BuildUpVertex.AssocIPTracksChi2RatioSecToPri" type="double" value="2.0" />
+    <parameter name="BuildUpVertex.UseV0Selection" type="int" value="1" />
+
+  </processor>
+
+
+  <!--################################################ -->
+
+  <processor name="MyComputeShowerShapesProcessor" type="ComputeShowerShapesProcessor">
+    <!--Performs Shower profile extraction-->
+    <!--Debugging?-->
+    <parameter name="Debug" type="int">0 </parameter>
+    <!--Name of the PFO collection-->
+    <parameter name="PFOCollection" type="string"> PandoraPFOs </parameter>
+    <!--Name of the Cluster collection-->
+    <parameter name="ClusterCollectionName" type="string"> PandoraClusters </parameter>
+    <!-- Radiation Length of Ecal-->
+    <parameter name="RadiationLength_Ecal" type="float">3.50 </parameter>
+    <!-- Radiation Length of Hcal-->
+    <parameter name="RadiationLength_Hcal" type="float">17.57 </parameter>
+    <!-- Moliere radius of Ecal-->
+    <parameter name="MoliereRadius_Ecal" type="float">9.00 </parameter>
+    <!-- Moliere radius of Hcal-->
+    <parameter name="MoliereRadius_Hcal" type="float">17.19 </parameter>
+  </processor>
+
+  <!--################################################ -->
+  <processor name="MyLikelihoodPID" type="LikelihoodPIDProcessor">
+    <!--Performs particle identification-->
+    <!--Debugging?-->
+    <parameter name="Debug" type="int">1 </parameter>
+    <!--Boundaries for energy binning-->
+    <parameter name="EnergyBoundaries" type="FloatVec">0 1.0e+07  </parameter>
+    <!--Name of files containing pdfs for charged particles-->
+    <parameter name="FilePDFName" type="StringVec"> LikelihoodPID_Histogram_v01.root </parameter>
+    <!-- Whether MVA low momentum mu/pi is used or not-->
+    <parameter name="UseLowMomentumMuPiSeparation" type="bool">
+      true
+    </parameter>
+    <parameter name="FileWeightFormupiSeparationName" type="StringVec">
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml
+      ./weightFiles_forLowMomentumMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml
+    </parameter>
+    
+    <!--dE/dx parameters for each particle-->
+    <parameter name="dEdxParameter_electron" type="FloatVec">
+      -2.40638e-03 7.10337e-01 2.87718e-01 -1.71591e+00 0.0
+    </parameter>
+    <parameter name="dEdxParameter_muon" type="FloatVec">
+      8.11408e-02 9.92207e-01 7.58509e+05 -1.70167e-01 4.63670e-04
+    </parameter>
+    <parameter name="dEdxParameter_pion" type="FloatVec">
+      8.10756e-02 -1.45051e+06 -3.09843e+04 2.84056e-01 3.38131e-04
+    </parameter>
+    <parameter name="dEdxParameter_kaon" type="FloatVec">
+      7.96117e-02 4.13335e+03 1.13577e+06 1.80555e-01 -3.15083e-04
+    </parameter>
+    <parameter name="dEdxParameter_proton" type="FloatVec">
+      7.78772e-02 4.49300e+04 9.13778e+04 1.50088e-01 -6.64184e-04
+    </parameter>
+
+    <!--dE/dx normalization-->
+    <parameter name="dEdxNormalization" type="float">
+      1.350e-7
+    </parameter>
+
+    <!--dE/dx error factor-->
+    <parameter name="dEdxErrorFactor" type="float">
+      7.55
+    </parameter>
+
+    <!-- Method: Maximum Likelihood(0) or Bayesian(1)-->
+    <parameter name="UseBayesian" type="int">
+      0
+    </parameter>
+
+    <!--Name of the PFO collection-->
+    <parameter name="RecoParticleCollection" type="string">PandoraPFOs</parameter>
+  </processor>
+
+  <!--################################################ -->
+  <processor name="MyTauFinder" type="TaJetClustering">
+    <!--Performs tau jet finding -->
+    <!--  0. Collections -->
+    <!--Input PFO collection-->
+    <parameter name="PFOCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <!--Tau output collection-->
+    <parameter name="OutputTauCollection" type="string" lcioOutType="ReconstructedParticle">TaJets </parameter>
+    <!--Remained PFO collection not clustered-->
+    <parameter name="RemainPFOCollection" type="string" lcioOutType="ReconstructedParticle">TaJetsRemainPFOs </parameter>
+    <!--  1. Clustering -->
+    <!--Tau mass for tau clustering [GeV]-->
+    <parameter name="TauMass" type="double">2 </parameter>
+    <!--Allowed cosine angle to be clustered-->
+    <parameter name="TauCosAngle" type="double">0.98 </parameter>
+    <!--  2. Primary cut -->
+    <!-- Skip ANY Primary and Cone cuts if true: should be only used in lepton-only final states! -->
+    <parameter name="NoSelection" type="int">0 </parameter>
+
+    <!--Primary cut include IMPLICIT selection of accepting only 1 or 3 tracks in jets:
+		this loosen the counting of low energy tracks-->
+    <parameter name="AcceptFlexibleLowEnergyTrack" type="int">1 </parameter>
+    <!--Minimum jet energy to be accepted as taus-->
+    <parameter name="MinimumJetEnergy" type="double">3 </parameter>
+    <!--Minimum track energy to be accepted as taus-->
+    <parameter name="MinimumTrackEnergy" type="double">2 </parameter>
+    <!--Minimum track energy to be counted-->
+    <parameter name="MinimumTrackEnergyAssoc" type="double">2 </parameter>
+    <!--  3. Cone cut: currently simple 1D cut -->
+    <!-- No cone selection if true -->
+    <parameter name="NoSelection" type="int">0 </parameter>
+
+    <!--Minimum cosine angle for cone-->
+    <parameter name="ConeMinCosAngle" type="double">0.9 </parameter>
+    <!--Maximum cosine angle for cone-->
+    <parameter name="ConeMaxCosAngle" type="double">1 </parameter>
+    <!--Energy fraction of cone compared to central-->
+    <parameter name="ConeMaxEnergyFrac" type="double">0.1 </parameter>
+  </processor>
+
+  <!--########## AddClusterProperties ###################################### -->
+  <processor name="BCalAddClusterProperties" type="AddClusterProperties">
+    <parameter name="PFOCollectionName" type="string" lcioInType="ReconstructedParticle"> BCalRecoParticle </parameter>
+    <parameter name="ClusterCollection" type="string" lcioInType="Cluster"> BCalClusters </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
+  </processor>
+
+  <!--########## PfoAnalysis ###################################### -->
+
+  <processor name="MyPfoAnalysis" type="PfoAnalysis">
+    <!--PfoAnalysis analyses output of PandoraPFANew-->
+    <!--Names of input pfo collection-->
+    <parameter name="PfoCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <!--Names of mc particle collection-->
+    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle">MCParticle </parameter>
+    <!-- Turn on calibration helper information-->
+    <parameter name="CollectCalibrationDetails" type="int"> 1 </parameter>
+    <!--ECal Collection ADC Names-->
+    <parameter name="ECalCollectionsSimCaloHit" type="StringVec" lcioInType="SimCalorimeterHit">EcalBarrelCollection EcalEndcapsCollection  EcalEndcapRingCollection</parameter>
+    <parameter name="ECalCollections" type="StringVec" lcioInType="CalorimeterHit">EcalBarrelCollectionRec EcalBarrelCollectionGapHits EcalEndcapsCollectionRec EcalEndcapsCollectionGapHits EcalEndcapRingCollectionRec</parameter>
+    <!--Name of the ECAL barrel collection used to form clusters-->
+    <parameter name="ECalBarrelCollections" type="StringVec" lcioInType="CalorimeterHit">EcalBarrelCollectionRec EcalBarrelCollectionGapHits</parameter>
+    <!--Name of the ECAL EndCap collection used to form clusters-->
+    <parameter name="ECalEndcapCollections" type="StringVec" lcioInType="CalorimeterHit">EcalEndcapsCollectionRec EcalEndcapsCollectionGapHits EcalEndcapRingCollectionRec</parameter>
+    <!--HCal Collection ADC Names-->
+    <parameter name="HCalCollectionsSimCaloHit" type="StringVec" lcioInType="SimCalorimeterHit">HcalBarrelRegCollection HcalEndcapsCollection HcalEndcapRingCollection</parameter>
+    <!--Name of the HCAL barrel collection used to form clusters-->
+    <parameter name="HCalBarrelCollectionsSimCaloHit" type="StringVec" lcioInType="SimCalorimeterHit">HcalBarrelRegCollection</parameter>
+    <!--Name of the HCAL EndCap collection used to form clusters-->
+    <parameter name="HCalEndCapCollectionsSimCaloHit" type="StringVec" lcioInType="SimCalorimeterHit">HcalEndcapsCollection</parameter>
+    <!--Name of the HCAL EndCap collection used to form clusters-->
+    <parameter name="HCalOtherCollectionsSimCaloHit" type="StringVec" lcioInType="SimCalorimeterHit">HcalEndcapRingCollection</parameter>
+    <!--Name of the HCAL collection used to form clusters-->
+    <parameter name="HCalCollections" type="StringVec" lcioInType="CalorimeterHit">HcalBarrelCollectionRec HcalEndcapsCollectionRec HcalEndcapRingCollectionRec </parameter>
+    <!--Name of the MUON collection used to form clusters-->
+    <parameter name="MuonCollections" type="StringVec" lcioInType="CalorimeterHit">MUON </parameter>
+    <!--Name of the BCAL collection used to form clusters-->
+    <parameter name="BCalCollections" type="StringVec" lcioInType="CalorimeterHit">BCAL</parameter>
+    <!--Name of the LHCAL collection used to form clusters-->
+    <parameter name="LHCalCollections" type="StringVec" lcioInType="CalorimeterHit">LHCAL</parameter>
+    <!--Name of the LCAL collection used to form clusters-->
+    <parameter name="LCalCollections" type="StringVec" lcioInType="CalorimeterHit">LCAL</parameter>
+    <!--Set the debug print level-->
+    <parameter name="Printing" type="int">0 </parameter>
+    <!--Name of the output root file-->
+    <parameter name="RootFile" type="string"> PfoAnalysis.root </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+  </processor>
+
+  <!--########## Add4MomCovMatrixCharged ###################################### -->
+  <!--Set the convariance matrix in (P,E) for all charged pfos in PandoraPFOs Collection-->
+  <processor name="MyAdd4MomCovMatrixCharged" type="Add4MomCovMatrixCharged">
+    <!--Name of the PandoraPFOs collection-->
+    <parameter name="InputPandoraPFOsCollection" type="String">PandoraPFOs</parameter>
+    <!--Verbosity lower than MESSAGE4 will print out cov. matrix for each pfo-->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE4 </parameter>
+  </processor>
+
+  <!--########## AddClusterProperties ###################################### -->
+  <processor name="MyAddClusterProperties" type="AddClusterProperties">
+    <parameter name="PFOCollectionName" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <parameter name="ClusterCollection" type="string" lcioInType="Cluster">PandoraClusters </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
+  </processor>
+
+  <processor name="MyPi0Finder" type="GammaGammaCandidateFinder">
+    <parameter name="InputParticleCollectionName" value="PandoraPFOs" />
+    <parameter name="GammaGammaResonanceName" value="Pi0" />
+    <parameter name="GammaGammaResonanceMass" value="0.1349766" />
+    <parameter name="MaxDeltaMgg" value="0.04" />
+    <parameter name="GammaMomentumCut" value="0.5" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="GammaGammaCandidatePi0s" />
+  </processor>
+
+  <processor name="MyEtaFinder" type="GammaGammaCandidateFinder">
+    <parameter name="InputParticleCollectionName" value="PandoraPFOs" />
+    <parameter name="GammaGammaResonanceName" value="Eta" />
+    <parameter name="GammaGammaResonanceMass" value="0.547862" />
+    <parameter name="MaxDeltaMgg" value="0.14" />
+    <parameter name="GammaMomentumCut" value="1.0" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="GammaGammaCandidateEtas" />
+  </processor>
+
+  <processor name="MyEtaPrimeFinder" type="GammaGammaCandidateFinder">
+    <parameter name="InputParticleCollectionName" value="PandoraPFOs" />
+    <parameter name="GammaGammaResonanceName" value="EtaPrime" />
+    <parameter name="GammaGammaResonanceMass" value="0.95778" />
+    <parameter name="MaxDeltaMgg" value="0.19" />
+    <parameter name="GammaMomentumCut" value="2.0" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="GammaGammaCandidateEtaPrimes" />
+  </processor>
+  
+  <processor name="MyGammaGammaSolutionFinder" type="GammaGammaSolutionFinder">
+    <parameter name="InputParticleCollectionName1" value="GammaGammaCandidatePi0s" />
+    <parameter name="InputParticleCollectionName2" value="GammaGammaCandidateEtas" />
+    <parameter name="InputParticleCollectionName3" value="GammaGammaCandidateEtaPrimes" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="GammaGammaParticles" />
+  </processor>
+
+  <processor name="MyDistilledPFOCreator" type="DistilledPFOCreator">
+    <parameter name="InputParticleCollectionName1" value="PandoraPFOsWithoutIsoLep" />
+    <parameter name="InputParticleCollectionName2" value="GammaGammaParticles" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="DistilledPFOs" />
+  </processor>
+
+
+  <processor name="SETDDSpacePointBuilder" type="DDSpacePointBuilder">
+    <!--SpacePointBuilder combine si-strip measurements into 3D spacepoints (1TrackerHitPlanar+1TrackHitPlanar = 1 TrackerHit), that can be used by reconstruction-->
+    <!--Name of sub detector-->
+    <parameter name="SubDetectorName" type="string"> SET </parameter>
+    <!--The length of the strips of the subdetector in mm-->
+    <parameter name="StripLength" type="Double"> 9.200000000e+01 </parameter>
+    <!--Name of the SpacePoint SimTrackerHit relation collection-->
+    <parameter name="SimHitSpacePointRelCollection" type="string" lcioOutType="LCRelation"> SETSpacePointRelations </parameter>
+    <!--SpacePointsCollection-->
+    <parameter name="SpacePointsCollection" type="string" lcioOutType="TrackerHit"> SETSpacePoints </parameter>
+    <!--TrackerHitCollection-->  
+    <parameter name="TrackerHitCollection" type="string" lcioInType="TrackerHitPlane"> SETTrackerHits </parameter>
+    <!--The name of the input collection of the relations of the TrackerHits to SimHits-->
+    <parameter name="TrackerHitSimHitRelCollection" type="string" lcioInType="LCRelation"> SETTrackerHitRelations </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
+  </processor>
+
+  <processor name="FTDDDSpacePointBuilder" type="DDSpacePointBuilder">
+    <!--SpacePointBuilder combine si-strip measurements into 3D spacepoints (1TrackerHitPlanar+1TrackHitPlanar = 1 TrackerHit), that can be used by reconstruction-->
+    <!--Name of sub detector-->
+    <parameter name="SubDetectorName" type="string"> FTD </parameter>
+    <!--The length of the strips of the subdetector in mm-->
+    <parameter name="StripLength" type="Double"> 2.500000000e+02 </parameter>
+    <!--Name of the SpacePoint SimTrackerHit relation collection-->
+    <parameter name="SimHitSpacePointRelCollection" type="string" lcioOutType="LCRelation"> FTDSpacePointRelations </parameter>
+    <!--SpacePointsCollection-->
+    <parameter name="SpacePointsCollection" type="string" lcioOutType="TrackerHit"> FTDSpacePoints </parameter>
+    <!--TrackerHitCollection-->  
+    <parameter name="TrackerHitCollection" type="string" lcioInType="TrackerHitPlane"> FTDStripTrackerHits </parameter>
+    <!--The name of the input collection of the relations of the TrackerHits to SimHits-->
+    <parameter name="TrackerHitSimHitRelCollection" type="string" lcioInType="LCRelation"> FTDStripTrackerHitRelations </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
+  </processor>
+  
+</marlin>


### PR DESCRIPTION
BEGINRELEASENOTES
- add stdreco file for ILD_ls5_v02 models w/ hybrid ecal
      - merge collections from even and odd layers for Ecal barrel and endcap
         before digitization
       - requires LCTuple > v01-08  ( for correct collection parameters )

ENDRELEASENOTES