### PR TITLE
 Change ILD default central silicon tracking to use DDCellsAutomatonMV.

### DIFF
--- a/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
+++ b/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
@@ -56,13 +56,13 @@
     
     <!-- ========== central silicon tracking =============== -->
     <!-- ========== standard DBD version =============== -->
-    <processor name="MySiliconTracking_MarlinTrk"/>  
+    <!-- <processor name="MySiliconTracking_MarlinTrk"/> -->
     <!-- ========== mini-vectors - make sure you use matching digitizer! =============== -->
     <!--processor name="MyCellsAutomatonMV_UseSIT"/-->
 
     <!-- need further investigation about the mini-vector tracking -->
-    <!-- <processor name="MyCellsAutomatonMV"/> -->
-    <!-- <processor name="MyExtrToSIT"/> -->
+    <processor name="MyCellsAutomatonMV"/>
+    <processor name="MyExtrToSIT"/>
 
     <!-- ========== FPCCD - make sure you use matching digitizer! =============== -->
     <!--processor name="MyFPCCDSiliconTracking_MarlinTrk"/-->  


### PR DESCRIPTION

BEGINRELEASENOTES
- Change ILD default central silicon tracking reconstruction.
    - Mini-vectors are created connecting two hits in neighbouring vertex barrel layers.
    - Cellular automaton is used to produce tracks from these mini-vectors which has been implemented into MarlinProcessor "DDCellsAutomatonMV".
    - It shows better tracking efficiency for the ILD. ILD will use it together with MarlinProcessor "ExtrToSIT" as default ILDConfig to replace MarlonProcessor "SiliconTracking_MarlinTrk".


ENDRELEASENOTES