### PR TITLE
FCAL MIP thresholds update

### DIFF
--- a/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
+++ b/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
@@ -1404,7 +1404,7 @@
     <!--LCAL Collection of real Hits-->
     <parameter name="FCALOutputCollection" type="string">BCAL</parameter>
     <!--Threshold for LCAL Hits in GeV-->
-    <parameter name="FcalThreshold" type="float">1e-06 </parameter>
+    <parameter name="FcalThreshold" type="float">0.4e-04</parameter>
     <!--MuonHit Relation Collection-->
     <parameter name="RelationOutputCollection" type="string">RelationBCalHit </parameter>
   </processor>
@@ -1428,7 +1428,7 @@
     <!--LCAL Collection of real Hits-->
     <parameter name="FCALOutputCollection" type="string">LCAL </parameter>
     <!--Threshold for LCALHits in GeV-->
-    <parameter name="FcalThreshold" type="float">0e-04 </parameter>
+    <parameter name="FcalThreshold" type="float">0.4e-04 </parameter>
     <!--LCALHit Relation Collection-->
     <parameter name="RelationOutputCollection" type="string">RelationLcalHit </parameter>
   </processor>
@@ -1451,7 +1451,7 @@
     <!--LHCAL Collection of real Hits-->
     <parameter name="FCALOutputCollection" type="string">LHCAL </parameter>
     <!--Threshold for LHCAL Hits in GeV-->
-    <parameter name="FcalThreshold" type="float">1e-06 </parameter>
+    <parameter name="FcalThreshold" type="float">1.7e-04 </parameter>
     <!--LHCALHit Relation Collection-->
     <parameter name="RelationOutputCollection" type="string">RelationLHcalHit </parameter>
   </processor>


### PR DESCRIPTION
BEGINRELEASENOTES
- FCAL MIP thresholds updated (BCAL, LCAL, LHCAL) using ILD_l4_model and a 0.5 cut from MIP peak

ENDRELEASENOTES