### PR TITLE
switch back to using SiliconTracking

### DIFF
--- a/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
+++ b/StandardConfig/lcgeo_current/bbudsc_3evt_stdreco_dd4hep.xml
@@ -56,13 +56,13 @@
     
     <!-- ========== central silicon tracking =============== -->
     <!-- ========== standard DBD version =============== -->
-    <!-- <processor name="MySiliconTracking_MarlinTrk"/> -->
+    <processor name="MySiliconTracking_MarlinTrk"/>
     <!-- ========== mini-vectors - make sure you use matching digitizer! =============== -->
     <!--processor name="MyCellsAutomatonMV_UseSIT"/-->
 
     <!-- need further investigation about the mini-vector tracking -->
-    <processor name="MyCellsAutomatonMV"/>
-    <processor name="MyExtrToSIT"/>
+    <!-- <processor name="MyCellsAutomatonMV"/> -->
+    <!-- <processor name="MyExtrToSIT"/> -->
 
     <!-- ========== FPCCD - make sure you use matching digitizer! =============== -->
     <!--processor name="MyFPCCDSiliconTracking_MarlinTrk"/-->  


### PR DESCRIPTION

BEGINRELEASENOTES
- switch back to using SiliconTracking rather than CellsAutomatonMV
      - this fixes the degraded impact parameter resolution at 20 deg 
      - reason is that no link is made from the VXD to the FTD and no SiTracks are created at this angle, which results in a large number of tracks having no VXD hits ...

ENDRELEASENOTES