### PR TITLE
 Added ILD CalorimeterHit information into LCTuple.

### DIFF
--- a/StandardConfig/lcgeo_current/lctuple.xml
+++ b/StandardConfig/lcgeo_current/lctuple.xml
@@ -16,6 +16,7 @@
   <processor name="MyAIDAProcessor"/>
   <processor name="MergeSimTrkHits" />
   <processor name="MergeSimCaloHits" />
+  <processor name="MergeCaloHits" />
   <processor name="MyLCTuple"/>  
  </execute>
 
@@ -27,7 +28,7 @@
   <parameter name="MaxRecordNumber" value="0" />  
   <parameter name="SkipNEvents" value="0"/>  
   <parameter name="SupressCheck" value="false" />  
-  <parameter name="GearXMLFile"> gear_ILD_o1_v05_dd4hep.xml </parameter>  
+  <parameter name="GearXMLFile"> gear_ILD_l4_v02.xml </parameter>
   <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">MESSAGE DEBUG  </parameter> 
   <parameter name="RandomSeed" value="1234567890" />
  </global>
@@ -50,6 +51,9 @@
 
   <!--Name of the Track collection-->
   <parameter name="TrackCollection" type="string" lcioInType="LDCTracks">MarlinTrkTracks</parameter>
+
+  <!--Name of the CalorimeterHit collection-->
+  <parameter name="CalorimeterHitCollection" type="string" lcioInType="CalorimeterHit">CalorimeterHits </parameter>
 
   <!--Name of the SimTrackerHit collection-->
   <parameter name="SimTrackerHitCollection" type="string" lcioInType="SimTrackerHit"> SimTrackerHits </parameter>
@@ -109,5 +113,30 @@
    <parameter name="Verbosity" type="string">DEBUG </parameter>
  </processor>
  
+ <processor name="MergeCaloHits" type="MergeCollections">
+   <!--MergeCollections creates a transient subset collection that merges all input collections -->
+   <!--Names of all input collections-->
+   <parameter name="InputCollections" type="StringVec">
+     EcalBarrelCollectionRec
+     EcalEndcapsCollectionRec
+     EcalEndcapRingCollectionRec
+     EcalBarrelCollectionGapHits
+     EcalEndcapsCollectionGapHits
+     HcalBarrelCollectionRec
+     HcalEndcapsCollectionRec
+     HcalEndcapRingCollectionRec
+     MUON
+     BCAL
+     LHCAL
+     LCAL
+   </parameter>
+  <!--Optional IDs for input collections - if given id will be added to all objects in merged collections as ext<CollID>()-->
+   <parameter name="InputCollectionIDs" type="IntVec">
+    0 1 2 3 4 5 6 7 8 9 10 11
+   </parameter>
+   <parameter name="OutputCollection" type="string">CalorimeterHits </parameter>
+   <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+   <parameter name="Verbosity" type="string">DEBUG </parameter>
+ </processor>
 
 </marlin>


### PR DESCRIPTION

BEGINRELEASENOTES
- merged all ILD CalorimeterHit which include the information after ILD calorimeters reconstruction.
- added ILD CalorimeterHits into the LCTuple
    - named as "scpox, scpoy, scpoz", sc... for SimCalorimeterHits after simulation
    - named as "capox,capoy,capoz, catim", ca... for CalorimeterHits after reconstruction

ENDRELEASENOTES