### PR TITLE
Adapt to DD4hep for accessing detector information and remove Gear fr…

### DIFF
--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -126,7 +126,6 @@
   <!-- ***** Global section ***** -->
   <global>
     <parameter name="LCIOInputFiles"> </parameter>
-    <parameter name="GearXMLFile" value="Gear/gear_${DetectorModel}.xml"/>
     <parameter name="MaxRecordNumber" value="0"/>
     <parameter name="SkipNEvents" value="0"/>
     <parameter name="SupressCheck" value="false"/>


### PR DESCRIPTION
…om ILD StdReco steering file.



BEGINRELEASENOTES
- Adapt to DD4hep for accessing detector information and remove Gear from ILD StdReco steering file.
    - If both PR https://github.com/iLCSoft/MarlinReco/pull/29 and https://github.com/iLCSoft/LCFIPlus/pull/3 are accepted
    - the gear file is not necessary anymore, and may be removed for ILD StdReco.

ENDRELEASENOTES