### PR TITLE
Overlay config updates

### DIFF
--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -36,25 +36,15 @@
     <constant name="CalibrationFile" value="Calibration/Calibration_${DetectorModel}.xml" />
   
     <!-- Whether to run the overlay background -->
-    <!-- WARNING : By setting this to true (or True), you must ensure that the overlay files are set in the following constants or in the processors directly -->
-    <constant name="RunOverlay" value="false" />
+    <!-- WARNING : By setting one this value to true (or True), you must ensure that the overlay files are set in the processor parameters -->
+    <constant name="RunOverlay250GeV" value="false" />
+    <constant name="RunOverlay350GeV" value="false" />
+    <constant name="RunOverlay500GeV" value="false" />    
+    <constant name="RunOverlay1000GeV" value="false" />
     
-    <!-- Overlay : expected background values. Default values based on 500 GeV case -->
-    <constant name="ExpBackgroundWW" value="0.211" />
-    <constant name="ExpBackgroundWB" value="0.24605" />
-    <constant name="ExpBackgroundBW" value="0.243873" />
-    <constant name="ExpBackgroundBB" value="0.35063" />
-  
     <!-- ***** Input files constants ***** -->
     <!-- Pandora settings file -->
     <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
-    
-    <!-- Overlay background files. Must be specified if the RunOverlay constant is set to true -->
-    <constant name="OverlayWWFiles"> undefined.slcio </constant>
-    <constant name="OverlayWBFiles"> undefined.slcio </constant>
-    <constant name="OverlayBWFiles"> undefined.slcio </constant>
-    <constant name="OverlayBBFiles"> undefined.slcio </constant>
-    <constant name="OverlayPairFiles"> undefined.slcio </constant>
     
     <!-- Special Beamcal overlay background file -->
     <constant name="BeamCalBackgroundFile" value="HighLevelReco/BeamCalBackground/BeamCal_bg_E500-TDR_ws.root" />
@@ -99,9 +89,19 @@
   <execute>
     <!-- Initialization processors -->
     <group name="Init" />
+
     <!-- Overlay background, if any (see constant RunOverlay) -->
-    <if condition="${RunOverlay}">
-      <group name="BgOverlay" />
+    <if condition="${RunOverlay250GeV}">
+      <group name="BgOverlay250GeV" />
+    </if>
+    <if condition="${RunOverlay350GeV}">
+      <group name="BgOverlay350GeV" />
+    </if>
+    <if condition="${RunOverlay500GeV}">
+      <group name="BgOverlay500GeV" />
+    </if>
+    <if condition="${RunOverlay1000GeV}">
+      <group name="BgOverlay1000GeV" />
     </if>
     <!-- Tracking digitizers -->
     <group name="TrackingDigi" />

--- a/StandardConfig/production/Overlay/Overlay.xml
+++ b/StandardConfig/production/Overlay/Overlay.xml
@@ -1,6 +1,6 @@
 
 
-<group name="BgOverlay">
+<group name="BgOverlay250GeV">
   
   <!--Overlay each event with this number of background events. (default 0)-->
   <parameter name="NumberOverlayEvents" type="int"> 0 </parameter>
@@ -12,54 +12,210 @@
   <parameter name="NSkipEventsRandom" type="int">0</parameter>
 
 
-  <processor name="BgOverlayWW" type="Overlay">
+  <processor name="BgOverlayWW250GeV" type="Overlay">
     <!--Opens a second (chain of) lcio file(s) and overlays events...-->
     <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
-    <parameter name="expBG" type="double">${ExpBackgroundWW}</parameter>
+    <parameter name="expBG" type="double"> -1 </parameter>
     <!--Name of the lcio input file(s)-->
-    <parameter name="InputFileNames" type="StringVec"> 
-      ${OverlayWWFiles}
-    </parameter>
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
   </processor>
   
-  <processor name="BgOverlayWB" type="Overlay">
+  <processor name="BgOverlayWB250GeV" type="Overlay">
     <!--Opens a second (chain of) lcio file(s) and overlays events...-->
     <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
-    <parameter name="expBG" type="double">${ExpBackgroundWB}</parameter>
+    <parameter name="expBG" type="double"> -1 </parameter>
     <!--Name of the lcio input file(s)-->
-    <parameter name="InputFileNames" type="StringVec"> 
-      ${OverlayWBFiles}
-    </parameter>
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
   </processor>
   
-  <processor name="BgOverlayBW" type="Overlay">
+  <processor name="BgOverlayBW250GeV" type="Overlay">
     <!--Opens a second (chain of) lcio file(s) and overlays events...-->
     <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
-    <parameter name="expBG" type="double">${ExpBackgroundBW}</parameter>
+    <parameter name="expBG" type="double"> -1 </parameter>
     <!--Name of the lcio input file(s)-->
-    <parameter name="InputFileNames" type="StringVec"> 
-      ${OverlayBWFiles}
-    </parameter>
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
   </processor>
   
-  <processor name="BgOverlayBB" type="Overlay">
+  <processor name="BgOverlayBB250GeV" type="Overlay">
     <!--Opens a second (chain of) lcio file(s) and overlays events...-->
     <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
-    <parameter name="expBG" type="double">${ExpBackgroundBB}</parameter>
+    <parameter name="expBG" type="double"> -1 </parameter>
     <!--Name of the lcio input file(s)-->
-    <parameter name="InputFileNames" type="StringVec"> 
-      ${OverlayBBFiles}
-    </parameter>
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
   </processor>
   
-  <processor name="PairBgOverlay" type="Overlay">
+  <processor name="PairBgOverlay250GeV" type="Overlay">
     <!--Opens a second (chain of) lcio file(s) and overlays events...-->
     <!--Overlay each event with this number of background events. (default 0)-->
     <parameter name="NumberOverlayEvents" type="int"> 1 </parameter>
     <!--Name of the lcio input file(s)-->
-    <parameter name="InputFileNames" type="StringVec"> 
-      ${OverlayPairFiles}
-    </parameter>
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+
+</group>
+
+
+<group name="BgOverlay350GeV">
+  
+  <!--Overlay each event with this number of background events. (default 0)-->
+  <parameter name="NumberOverlayEvents" type="int"> 0 </parameter>
+
+  <!--Overlay each event with the content of one run.-->
+  <parameter name="runOverlay" type="bool">false </parameter>
+
+  <!--Maximum number of events to skip between overlayd events (choosen from flat intervall [0,NSkipEventsRandom] )-->
+  <parameter name="NSkipEventsRandom" type="int">0</parameter>
+
+
+  <processor name="BgOverlayWW350GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double"> -1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayWB350GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double"> -1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayBW350GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double"> -1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayBB350GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double"> -1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="PairBgOverlay350GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Overlay each event with this number of background events. (default 0)-->
+    <parameter name="NumberOverlayEvents" type="int"> 1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+
+</group>
+
+
+
+<group name="BgOverlay500GeV">
+  
+  <!--Overlay each event with this number of background events. (default 0)-->
+  <parameter name="NumberOverlayEvents" type="int"> 0 </parameter>
+
+  <!--Overlay each event with the content of one run.-->
+  <parameter name="runOverlay" type="bool">false </parameter>
+
+  <!--Maximum number of events to skip between overlayd events (choosen from flat intervall [0,NSkipEventsRandom] )-->
+  <parameter name="NSkipEventsRandom" type="int">0</parameter>
+
+
+  <processor name="BgOverlayWW500GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double">0.211</parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayWB500GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double">0.24605</parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayBW500GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double">0.243873</parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayBB500GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double">0.35063</parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="PairBgOverlay500GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Overlay each event with this number of background events. (default 0)-->
+    <parameter name="NumberOverlayEvents" type="int"> 1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+
+</group>
+
+
+<group name="BgOverlay1000GeV">
+  
+  <!--Overlay each event with this number of background events. (default 0)-->
+  <parameter name="NumberOverlayEvents" type="int"> 0 </parameter>
+
+  <!--Overlay each event with the content of one run.-->
+  <parameter name="runOverlay" type="bool">false </parameter>
+
+  <!--Maximum number of events to skip between overlayd events (choosen from flat intervall [0,NSkipEventsRandom] )-->
+  <parameter name="NSkipEventsRandom" type="int">0</parameter>
+
+
+  <processor name="BgOverlayWW1000GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double"> -1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayWB1000GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double"> -1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayBW1000GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double"> -1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="BgOverlayBB1000GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Add additional background events according to a poisson distribution with this expectation value. (non, if parameter not set)-->
+    <parameter name="expBG" type="double"> -1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
+  </processor>
+  
+  <processor name="PairBgOverlay1000GeV" type="Overlay">
+    <!--Opens a second (chain of) lcio file(s) and overlays events...-->
+    <!--Overlay each event with this number of background events. (default 0)-->
+    <parameter name="NumberOverlayEvents" type="int"> 1 </parameter>
+    <!--Name of the lcio input file(s)-->
+    <parameter name="InputFileNames" type="StringVec"> undefined.slcio </parameter>
   </processor>
 
 </group>


### PR DESCRIPTION
BEGINRELEASENOTES
- Setup overlay config for each center of mass energy into processor groups : 
  - added condition to execute a given overlay group by using a constant
  - removed file names and expBG configuration from constants section
  - set expBG values for 500 GeV to known values
  - set expBG values for 250, 350 and 1000 GeV to -1 (not communicated yet)

Example to run at 500 GeV : 
```shell
Marlin --constant.RunOverlay500GeV=true \
--BgOverlayWW500GeV.InputFileNames=WWfile.slcio \
--BgOverlayWB500GeV.InputFileNames=WBfile.slcio \
--BgOverlayBW500GeV.InputFileNames=BWfile.slcio \
--BgOverlayBB500GeV.InputFileNames=BBfile.slcio \
--PairBgOverlay500GeV.InputFileNames=Pairfile.slcio \
./ProductionSteeringFiles/MarlinStdReco_ILD_l5_o1_v02.xml
```

ENDRELEASENOTES