### PR TITLE
Calibration updates

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.xml
@@ -13,6 +13,7 @@
 <constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
 <constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
 <constant name="HcalRingEnergyFactors">0.0359436163529</constant>
+<constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">149.254</constant>
 <constant name="PandoraHcalToMip">35.3357</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
@@ -21,6 +22,7 @@
 <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
 <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.78321 -0.0515853 0.000555338 -0.0858048 0.00546042 -0.000151165 0.0601101 0.069058 -0.113743</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
@@ -8,6 +8,7 @@
 <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
 <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
 <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
+<constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">149.254</constant>
 <constant name="PandoraHcalToMip">35.3357</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
@@ -16,6 +17,7 @@
 <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
 <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.78321 -0.0515853 0.000555338 -0.0858048 0.00546042 -0.000151165 0.0601101 0.069058 -0.113743</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
@@ -1,26 +1,28 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
-<constant name="EcalRingMip">0.0001575</constant>
+<constant name="EcalBarrelMip">0.0001525</constant>
+<constant name="EcalEndcapMip">0.0001525</constant>
+<constant name="EcalRingMip">0.0001525</constant>
 <constant name="HcalBarrelMip">0.0004925</constant>
-<constant name="HcalEndcapMip">0.0004725</constant>
+<constant name="HcalEndcapMip">0.0004775</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-<constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-<constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-<constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
-<constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
-<constant name="HcalRingEnergyFactors">0.0359436163529</constant>
-<constant name="PandoraEcalToMip">149.254</constant>
-<constant name="PandoraHcalToMip">35.3357</constant>
+<constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
+<constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="HcalBarrelEnergyFactors">0.0216747245411</constant>
+<constant name="HcalEndcapEnergyFactors">0.0217395864899</constant>
+<constant name="HcalRingEnergyFactors">0.0271318181372</constant>
+<constant name="MuonCalibration">56.7</constant>
+<constant name="PandoraEcalToMip">153.846</constant>
+<constant name="PandoraHcalToMip">43.29</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
@@ -1,21 +1,23 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
-<constant name="EcalRingMip">0.0001575</constant>
+<constant name="EcalBarrelMip">0.0001525</constant>
+<constant name="EcalEndcapMip">0.0001525</constant>
+<constant name="EcalRingMip">0.0001525</constant>
 <constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
-<constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-<constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-<constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-<constant name="PandoraEcalToMip">149.254</constant>
-<constant name="PandoraHcalToMip">35.3357</constant>
+<constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
+<constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="MuonCalibration">56.7</constant>
+<constant name="PandoraEcalToMip">153.846</constant>
+<constant name="PandoraHcalToMip">43.29</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -1,26 +1,28 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
-<constant name="EcalRingMip">0.0001575</constant>
+<constant name="EcalBarrelMip">0.0001525</constant>
+<constant name="EcalEndcapMip">0.0001525</constant>
+<constant name="EcalRingMip">0.0001525</constant>
 <constant name="HcalBarrelMip">0.0004925</constant>
-<constant name="HcalEndcapMip">0.0004725</constant>
+<constant name="HcalEndcapMip">0.0004775</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-<constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-<constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-<constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
-<constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
-<constant name="HcalRingEnergyFactors">0.0359436163529</constant>
-<constant name="PandoraEcalToMip">149.254</constant>
-<constant name="PandoraHcalToMip">35.3357</constant>
+<constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
+<constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="HcalBarrelEnergyFactors">0.0216747245411</constant>
+<constant name="HcalEndcapEnergyFactors">0.0217395864899</constant>
+<constant name="HcalRingEnergyFactors">0.0271318181372</constant>
+<constant name="MuonCalibration">56.7</constant>
+<constant name="PandoraEcalToMip">153.846</constant>
+<constant name="PandoraHcalToMip">43.29</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
@@ -1,21 +1,23 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
-<constant name="EcalRingMip">0.0001575</constant>
+<constant name="EcalBarrelMip">0.0001525</constant>
+<constant name="EcalEndcapMip">0.0001525</constant>
+<constant name="EcalRingMip">0.0001525</constant>
 <constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
-<constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-<constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-<constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-<constant name="PandoraEcalToMip">149.254</constant>
-<constant name="PandoraHcalToMip">35.3357</constant>
+<constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
+<constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="MuonCalibration">56.7</constant>
+<constant name="PandoraEcalToMip">153.846</constant>
+<constant name="PandoraHcalToMip">43.29</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.xml
@@ -13,6 +13,7 @@
 <constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
 <constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
 <constant name="HcalRingEnergyFactors">0.0359436163529</constant>
+<constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">149.254</constant>
 <constant name="PandoraHcalToMip">35.3357</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
@@ -21,6 +22,7 @@
 <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
 <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.67738 -0.0324571 0.000211756 -0.0652524 0.00258787 -4.47897e-05 0.057609 0.0659326 -0.0757052</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
@@ -8,6 +8,7 @@
 <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
 <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
 <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
+<constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">149.254</constant>
 <constant name="PandoraHcalToMip">35.3357</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
@@ -16,6 +17,7 @@
 <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
 <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.67738 -0.0324571 0.000211756 -0.0652524 0.00258787 -4.47897e-05 0.057609 0.0659326 -0.0757052</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
@@ -1,26 +1,28 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
-<constant name="EcalRingMip">0.0001575</constant>
-<constant name="HcalBarrelMip">0.0004925</constant>
-<constant name="HcalEndcapMip">0.0004725</constant>
+<constant name="EcalBarrelMip">0.0001525</constant>
+<constant name="EcalEndcapMip">0.0001525</constant>
+<constant name="EcalRingMip">0.0001525</constant>
+<constant name="HcalBarrelMip">0.0004975</constant>
+<constant name="HcalEndcapMip">0.0004775</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-<constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-<constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-<constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
-<constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
-<constant name="HcalRingEnergyFactors">0.0359436163529</constant>
-<constant name="PandoraEcalToMip">149.254</constant>
-<constant name="PandoraHcalToMip">35.3357</constant>
+<constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
+<constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
+<constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
+<constant name="HcalBarrelEnergyFactors">0.0222191436885</constant>
+<constant name="HcalEndcapEnergyFactors">0.0217589517814</constant>
+<constant name="HcalRingEnergyFactors">0.0256860106028</constant>
+<constant name="MuonCalibration">56.7</constant>
+<constant name="PandoraEcalToMip">153.846</constant>
+<constant name="PandoraHcalToMip">42.1941</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-<constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+<constant name="PandoraHcalToHadScale">1.0518169704</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
@@ -1,21 +1,23 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
-<constant name="EcalRingMip">0.0001575</constant>
+<constant name="EcalBarrelMip">0.0001525</constant>
+<constant name="EcalEndcapMip">0.0001525</constant>
+<constant name="EcalRingMip">0.0001525</constant>
+<constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
+<constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
+<constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
 <constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
-<constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-<constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-<constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-<constant name="PandoraEcalToMip">149.254</constant>
-<constant name="PandoraHcalToMip">35.3357</constant>
+<constant name="MuonCalibration">56.7</constant>
+<constant name="PandoraEcalToMip">153.846</constant>
+<constant name="PandoraHcalToMip">42.1941</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-<constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+<constant name="PandoraHcalToHadScale">1.0518169704</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -1,26 +1,28 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
-<constant name="EcalRingMip">0.0001575</constant>
-<constant name="HcalBarrelMip">0.0004925</constant>
-<constant name="HcalEndcapMip">0.0004725</constant>
+<constant name="EcalBarrelMip">0.0001525</constant>
+<constant name="EcalEndcapMip">0.0001525</constant>
+<constant name="EcalRingMip">0.0001525</constant>
+<constant name="HcalBarrelMip">0.0004975</constant>
+<constant name="HcalEndcapMip">0.0004775</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-<constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-<constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-<constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
-<constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
-<constant name="HcalRingEnergyFactors">0.0359436163529</constant>
-<constant name="PandoraEcalToMip">149.254</constant>
-<constant name="PandoraHcalToMip">35.3357</constant>
+<constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
+<constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
+<constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
+<constant name="HcalBarrelEnergyFactors">0.0222191436885</constant>
+<constant name="HcalEndcapEnergyFactors">0.0217589517814</constant>
+<constant name="HcalRingEnergyFactors">0.0256860106028</constant>
+<constant name="MuonCalibration">56.7</constant>
+<constant name="PandoraEcalToMip">153.846</constant>
+<constant name="PandoraHcalToMip">42.1941</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-<constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+<constant name="PandoraHcalToHadScale">1.0518169704</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
@@ -1,21 +1,23 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
-<constant name="EcalRingMip">0.0001575</constant>
+<constant name="EcalBarrelMip">0.0001525</constant>
+<constant name="EcalEndcapMip">0.0001525</constant>
+<constant name="EcalRingMip">0.0001525</constant>
+<constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
+<constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
+<constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
 <constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
-<constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-<constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-<constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-<constant name="PandoraEcalToMip">149.254</constant>
-<constant name="PandoraHcalToMip">35.3357</constant>
+<constant name="MuonCalibration">56.7</constant>
+<constant name="PandoraEcalToMip">153.846</constant>
+<constant name="PandoraHcalToMip">42.1941</constant>
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-<constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+<constant name="PandoraHcalToHadScale">1.0518169704</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/CaloDigi/MuonDigi.xml
+++ b/StandardConfig/production/CaloDigi/MuonDigi.xml
@@ -9,7 +9,7 @@
     <parameter name="CellIDLayerString" type="string"> layer </parameter>
     
     <!--Calibration coefficients for MUON-->
-    <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+    <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
     <!-- maximum hit energy for a MUON hit -->
     <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
     <!--MUON Collection Names-->

--- a/StandardConfig/production/ParticleFlow/PandoraPFA.xml
+++ b/StandardConfig/production/ParticleFlow/PandoraPFA.xml
@@ -23,22 +23,22 @@
     <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
     <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
     <!-- Calibration constants -->
-    <parameter name="ECalToMipCalibration">149.254</parameter>
-    <parameter name="HCalToMipCalibration">35.3357</parameter>
-    <parameter name="MuonToMipCalibration">10.3093</parameter>
+    <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+    <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+    <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
     <parameter name="ECalMipThreshold" type="float">0.5</parameter>
     <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-    <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-    <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-    <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-    <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-    <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+    <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+    <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+    <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+    <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+    <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
     <parameter name="DigitalMuonHits" type="int">0</parameter>
     <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter> 
-    <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+    <parameter name="SoftwareCompensationWeights" type="FloatVec"> ${PandoraSoftwareCompensationWeights} </parameter>
     <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0  2  5  7.5  9.5  13  16  20  23.5  28</parameter>
     <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-    <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+    <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
     <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
     <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
     <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l4_o1_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l4_o1_v02.xml
@@ -57,6 +57,7 @@
         <constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
         <constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
         <constant name="HcalRingEnergyFactors">0.0359436163529</constant>
+        <constant name="MuonCalibration">56.7</constant>
         <constant name="PandoraEcalToMip">149.254</constant>
         <constant name="PandoraHcalToMip">35.3357</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
@@ -65,6 +66,7 @@
         <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
         <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
         <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.78321 -0.0515853 0.000555338 -0.0858048 0.00546042 -0.000151165 0.0601101 0.069058 -0.113743</constant>
         <constant name="EcalTechnology" value="SiWEcal" />
         <constant name="HcalTechnology" value="AHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
@@ -1151,7 +1153,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1185,22 +1187,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l4_o2_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l4_o2_v02.xml
@@ -52,6 +52,7 @@
         <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
         <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
         <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
+        <constant name="MuonCalibration">56.7</constant>
         <constant name="PandoraEcalToMip">149.254</constant>
         <constant name="PandoraHcalToMip">35.3357</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
@@ -60,6 +61,7 @@
         <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
         <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
         <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.78321 -0.0515853 0.000555338 -0.0858048 0.00546042 -0.000151165 0.0601101 0.069058 -0.113743</constant>
         <constant name="EcalTechnology" value="SiWEcal" />
         <constant name="HcalTechnology" value="SDHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
@@ -1113,7 +1115,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1147,22 +1149,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l5_o1_v02.xml
@@ -24,7 +24,7 @@
     <constants>
         <!-- ***** Global constant for reconstruction ***** -->
         <!-- The lcgeo directory where to look for the ILD model -->
-        <constant name="lcgeo_DIR" value="/path/to/lcgeo_DIR" />
+        <constant name="lcgeo_DIR" value="/afs/desy.de/project/ilcsoft/sw/x86_64_gcc49_sl6/v01-19-05-pre05/lcgeo/v00-15-01" />
         <!-- ILD detector model -->
         <constant name="DetectorModel" value="ILD_l5_o1_v02" />
         <!-- The full compact file name -->
@@ -45,26 +45,28 @@
         <!-- Particle identification BDT weights file for low momemtum mu/pi separation -->
         <constant name="PidWeightFiles">HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml</constant>
         <!-- Geometry model dependant calibration constants from external file -->
-        <constant name="EcalBarrelMip">0.0001575</constant>
-        <constant name="EcalEndcapMip">0.0001575</constant>
-        <constant name="EcalRingMip">0.0001575</constant>
+        <constant name="EcalBarrelMip">0.0001525</constant>
+        <constant name="EcalEndcapMip">0.0001525</constant>
+        <constant name="EcalRingMip">0.0001525</constant>
         <constant name="HcalBarrelMip">0.0004925</constant>
-        <constant name="HcalEndcapMip">0.0004725</constant>
+        <constant name="HcalEndcapMip">0.0004775</constant>
         <constant name="HcalRingMip">0.0004875</constant>
-        <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-        <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-        <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-        <constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
-        <constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
-        <constant name="HcalRingEnergyFactors">0.0359436163529</constant>
-        <constant name="PandoraEcalToMip">149.254</constant>
-        <constant name="PandoraHcalToMip">35.3357</constant>
+        <constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
+        <constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
+        <constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+        <constant name="HcalBarrelEnergyFactors">0.0216747245411</constant>
+        <constant name="HcalEndcapEnergyFactors">0.0217395864899</constant>
+        <constant name="HcalRingEnergyFactors">0.0271318181372</constant>
+        <constant name="MuonCalibration">56.7</constant>
+        <constant name="PandoraEcalToMip">153.846</constant>
+        <constant name="PandoraHcalToMip">43.29</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
         <constant name="PandoraEcalToEMScale">1.0</constant>
         <constant name="PandoraHcalToEMScale">1.0</constant>
-        <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-        <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
+        <constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
+        <constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
         <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
         <constant name="EcalTechnology" value="SiWEcal" />
         <constant name="HcalTechnology" value="AHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
@@ -1151,7 +1153,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1185,22 +1187,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l5_o2_v02.xml
@@ -24,7 +24,7 @@
     <constants>
         <!-- ***** Global constant for reconstruction ***** -->
         <!-- The lcgeo directory where to look for the ILD model -->
-        <constant name="lcgeo_DIR" value="/afs/desy.de/project/ilcsoft/sw/x86_64_gcc49_sl6/v01-19-05-pre05/lcgeo/v00-15-01" />
+        <constant name="lcgeo_DIR" value="/path/to/lcgeo_DIR" />
         <!-- ILD detector model -->
         <constant name="DetectorModel" value="ILD_l5_o2_v02" />
         <!-- The full compact file name -->
@@ -45,21 +45,23 @@
         <!-- Particle identification BDT weights file for low momemtum mu/pi separation -->
         <constant name="PidWeightFiles">HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml</constant>
         <!-- Geometry model dependant calibration constants from external file -->
-        <constant name="EcalBarrelMip">0.0001575</constant>
-        <constant name="EcalEndcapMip">0.0001575</constant>
-        <constant name="EcalRingMip">0.0001575</constant>
+        <constant name="EcalBarrelMip">0.0001525</constant>
+        <constant name="EcalEndcapMip">0.0001525</constant>
+        <constant name="EcalRingMip">0.0001525</constant>
         <constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
-        <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-        <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-        <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-        <constant name="PandoraEcalToMip">149.254</constant>
-        <constant name="PandoraHcalToMip">35.3357</constant>
+        <constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
+        <constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
+        <constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+        <constant name="MuonCalibration">56.7</constant>
+        <constant name="PandoraEcalToMip">153.846</constant>
+        <constant name="PandoraHcalToMip">43.29</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
         <constant name="PandoraEcalToEMScale">1.0</constant>
         <constant name="PandoraHcalToEMScale">1.0</constant>
-        <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-        <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
+        <constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
+        <constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
         <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
         <constant name="EcalTechnology" value="SiWEcal" />
         <constant name="HcalTechnology" value="SDHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
@@ -1113,7 +1115,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1147,22 +1149,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l5_o3_v02.xml
@@ -45,26 +45,28 @@
         <!-- Particle identification BDT weights file for low momemtum mu/pi separation -->
         <constant name="PidWeightFiles">HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml</constant>
         <!-- Geometry model dependant calibration constants from external file -->
-        <constant name="EcalBarrelMip">0.0001575</constant>
-        <constant name="EcalEndcapMip">0.0001575</constant>
-        <constant name="EcalRingMip">0.0001575</constant>
+        <constant name="EcalBarrelMip">0.0001525</constant>
+        <constant name="EcalEndcapMip">0.0001525</constant>
+        <constant name="EcalRingMip">0.0001525</constant>
         <constant name="HcalBarrelMip">0.0004925</constant>
-        <constant name="HcalEndcapMip">0.0004725</constant>
+        <constant name="HcalEndcapMip">0.0004775</constant>
         <constant name="HcalRingMip">0.0004875</constant>
-        <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-        <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-        <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-        <constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
-        <constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
-        <constant name="HcalRingEnergyFactors">0.0359436163529</constant>
-        <constant name="PandoraEcalToMip">149.254</constant>
-        <constant name="PandoraHcalToMip">35.3357</constant>
+        <constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
+        <constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
+        <constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+        <constant name="HcalBarrelEnergyFactors">0.0216747245411</constant>
+        <constant name="HcalEndcapEnergyFactors">0.0217395864899</constant>
+        <constant name="HcalRingEnergyFactors">0.0271318181372</constant>
+        <constant name="MuonCalibration">56.7</constant>
+        <constant name="PandoraEcalToMip">153.846</constant>
+        <constant name="PandoraHcalToMip">43.29</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
         <constant name="PandoraEcalToEMScale">1.0</constant>
         <constant name="PandoraHcalToEMScale">1.0</constant>
-        <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-        <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
+        <constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
+        <constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
         <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
         <constant name="EcalTechnology" value="ScEcal" />
         <constant name="HcalTechnology" value="AHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
@@ -1151,7 +1153,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1185,22 +1187,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l5_o4_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_l5_o4_v02.xml
@@ -45,21 +45,23 @@
         <!-- Particle identification BDT weights file for low momemtum mu/pi separation -->
         <constant name="PidWeightFiles">HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml</constant>
         <!-- Geometry model dependant calibration constants from external file -->
-        <constant name="EcalBarrelMip">0.0001575</constant>
-        <constant name="EcalEndcapMip">0.0001575</constant>
-        <constant name="EcalRingMip">0.0001575</constant>
+        <constant name="EcalBarrelMip">0.0001525</constant>
+        <constant name="EcalEndcapMip">0.0001525</constant>
+        <constant name="EcalRingMip">0.0001525</constant>
         <constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
-        <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-        <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-        <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-        <constant name="PandoraEcalToMip">149.254</constant>
-        <constant name="PandoraHcalToMip">35.3357</constant>
+        <constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
+        <constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
+        <constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+        <constant name="MuonCalibration">56.7</constant>
+        <constant name="PandoraEcalToMip">153.846</constant>
+        <constant name="PandoraHcalToMip">43.29</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
         <constant name="PandoraEcalToEMScale">1.0</constant>
         <constant name="PandoraHcalToEMScale">1.0</constant>
-        <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-        <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
+        <constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
+        <constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
         <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
         <constant name="EcalTechnology" value="ScEcal" />
         <constant name="HcalTechnology" value="SDHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
@@ -1113,7 +1115,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1147,22 +1149,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s4_o1_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s4_o1_v02.xml
@@ -57,6 +57,7 @@
         <constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
         <constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
         <constant name="HcalRingEnergyFactors">0.0359436163529</constant>
+        <constant name="MuonCalibration">56.7</constant>
         <constant name="PandoraEcalToMip">149.254</constant>
         <constant name="PandoraHcalToMip">35.3357</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
@@ -65,6 +66,7 @@
         <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
         <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
         <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.67738 -0.0324571 0.000211756 -0.0652524 0.00258787 -4.47897e-05 0.057609 0.0659326 -0.0757052</constant>
         <constant name="EcalTechnology" value="SiWEcal" />
         <constant name="HcalTechnology" value="AHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
@@ -1151,7 +1153,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1185,22 +1187,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s4_o2_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s4_o2_v02.xml
@@ -52,6 +52,7 @@
         <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
         <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
         <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
+        <constant name="MuonCalibration">56.7</constant>
         <constant name="PandoraEcalToMip">149.254</constant>
         <constant name="PandoraHcalToMip">35.3357</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
@@ -60,6 +61,7 @@
         <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
         <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
         <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.67738 -0.0324571 0.000211756 -0.0652524 0.00258787 -4.47897e-05 0.057609 0.0659326 -0.0757052</constant>
         <constant name="EcalTechnology" value="SiWEcal" />
         <constant name="HcalTechnology" value="SDHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
@@ -1113,7 +1115,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1147,22 +1149,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s5_o1_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s5_o1_v02.xml
@@ -45,26 +45,28 @@
         <!-- Particle identification BDT weights file for low momemtum mu/pi separation -->
         <constant name="PidWeightFiles">HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml</constant>
         <!-- Geometry model dependant calibration constants from external file -->
-        <constant name="EcalBarrelMip">0.0001575</constant>
-        <constant name="EcalEndcapMip">0.0001575</constant>
-        <constant name="EcalRingMip">0.0001575</constant>
-        <constant name="HcalBarrelMip">0.0004925</constant>
-        <constant name="HcalEndcapMip">0.0004725</constant>
+        <constant name="EcalBarrelMip">0.0001525</constant>
+        <constant name="EcalEndcapMip">0.0001525</constant>
+        <constant name="EcalRingMip">0.0001525</constant>
+        <constant name="HcalBarrelMip">0.0004975</constant>
+        <constant name="HcalEndcapMip">0.0004775</constant>
         <constant name="HcalRingMip">0.0004875</constant>
-        <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-        <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-        <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-        <constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
-        <constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
-        <constant name="HcalRingEnergyFactors">0.0359436163529</constant>
-        <constant name="PandoraEcalToMip">149.254</constant>
-        <constant name="PandoraHcalToMip">35.3357</constant>
+        <constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
+        <constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
+        <constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
+        <constant name="HcalBarrelEnergyFactors">0.0222191436885</constant>
+        <constant name="HcalEndcapEnergyFactors">0.0217589517814</constant>
+        <constant name="HcalRingEnergyFactors">0.0256860106028</constant>
+        <constant name="MuonCalibration">56.7</constant>
+        <constant name="PandoraEcalToMip">153.846</constant>
+        <constant name="PandoraHcalToMip">42.1941</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
         <constant name="PandoraEcalToEMScale">1.0</constant>
         <constant name="PandoraHcalToEMScale">1.0</constant>
-        <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-        <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-        <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
+        <constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+        <constant name="PandoraHcalToHadScale">1.0518169704</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
         <constant name="EcalTechnology" value="SiWEcal" />
         <constant name="HcalTechnology" value="AHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
@@ -1151,7 +1153,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1185,22 +1187,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s5_o2_v02.xml
@@ -45,21 +45,23 @@
         <!-- Particle identification BDT weights file for low momemtum mu/pi separation -->
         <constant name="PidWeightFiles">HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml</constant>
         <!-- Geometry model dependant calibration constants from external file -->
-        <constant name="EcalBarrelMip">0.0001575</constant>
-        <constant name="EcalEndcapMip">0.0001575</constant>
-        <constant name="EcalRingMip">0.0001575</constant>
+        <constant name="EcalBarrelMip">0.0001525</constant>
+        <constant name="EcalEndcapMip">0.0001525</constant>
+        <constant name="EcalRingMip">0.0001525</constant>
+        <constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
+        <constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
+        <constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
         <constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
-        <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-        <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-        <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-        <constant name="PandoraEcalToMip">149.254</constant>
-        <constant name="PandoraHcalToMip">35.3357</constant>
+        <constant name="MuonCalibration">56.7</constant>
+        <constant name="PandoraEcalToMip">153.846</constant>
+        <constant name="PandoraHcalToMip">42.1941</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
         <constant name="PandoraEcalToEMScale">1.0</constant>
         <constant name="PandoraHcalToEMScale">1.0</constant>
-        <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-        <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-        <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
+        <constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+        <constant name="PandoraHcalToHadScale">1.0518169704</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
         <constant name="EcalTechnology" value="SiWEcal" />
         <constant name="HcalTechnology" value="SDHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
@@ -1113,7 +1115,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1147,22 +1149,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s5_o3_v02.xml
@@ -45,26 +45,28 @@
         <!-- Particle identification BDT weights file for low momemtum mu/pi separation -->
         <constant name="PidWeightFiles">HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml</constant>
         <!-- Geometry model dependant calibration constants from external file -->
-        <constant name="EcalBarrelMip">0.0001575</constant>
-        <constant name="EcalEndcapMip">0.0001575</constant>
-        <constant name="EcalRingMip">0.0001575</constant>
-        <constant name="HcalBarrelMip">0.0004925</constant>
-        <constant name="HcalEndcapMip">0.0004725</constant>
+        <constant name="EcalBarrelMip">0.0001525</constant>
+        <constant name="EcalEndcapMip">0.0001525</constant>
+        <constant name="EcalRingMip">0.0001525</constant>
+        <constant name="HcalBarrelMip">0.0004975</constant>
+        <constant name="HcalEndcapMip">0.0004775</constant>
         <constant name="HcalRingMip">0.0004875</constant>
-        <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-        <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-        <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-        <constant name="HcalBarrelEnergyFactors">0.0282939686687</constant>
-        <constant name="HcalEndcapEnergyFactors">0.0300448694145</constant>
-        <constant name="HcalRingEnergyFactors">0.0359436163529</constant>
-        <constant name="PandoraEcalToMip">149.254</constant>
-        <constant name="PandoraHcalToMip">35.3357</constant>
+        <constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
+        <constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
+        <constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
+        <constant name="HcalBarrelEnergyFactors">0.0222191436885</constant>
+        <constant name="HcalEndcapEnergyFactors">0.0217589517814</constant>
+        <constant name="HcalRingEnergyFactors">0.0256860106028</constant>
+        <constant name="MuonCalibration">56.7</constant>
+        <constant name="PandoraEcalToMip">153.846</constant>
+        <constant name="PandoraHcalToMip">42.1941</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
         <constant name="PandoraEcalToEMScale">1.0</constant>
         <constant name="PandoraHcalToEMScale">1.0</constant>
-        <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-        <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-        <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
+        <constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+        <constant name="PandoraHcalToHadScale">1.0518169704</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
         <constant name="EcalTechnology" value="ScEcal" />
         <constant name="HcalTechnology" value="AHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
@@ -1151,7 +1153,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1185,22 +1187,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>

--- a/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s5_o4_v02.xml
+++ b/StandardConfig/production/ProductionSteeringFiles/MarlinStdReco_ILD_s5_o4_v02.xml
@@ -45,21 +45,23 @@
         <!-- Particle identification BDT weights file for low momemtum mu/pi separation -->
         <constant name="PidWeightFiles">HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_02GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_03GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_04GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_05GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_06GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_07GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_08GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_09GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_10GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_11GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_12GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_13GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_14GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_15GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_16GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_17GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_18GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_19GeVP_clusterinfo.weights.xml HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_20GeVP_clusterinfo.weights.xml</constant>
         <!-- Geometry model dependant calibration constants from external file -->
-        <constant name="EcalBarrelMip">0.0001575</constant>
-        <constant name="EcalEndcapMip">0.0001575</constant>
-        <constant name="EcalRingMip">0.0001575</constant>
+        <constant name="EcalBarrelMip">0.0001525</constant>
+        <constant name="EcalEndcapMip">0.0001525</constant>
+        <constant name="EcalRingMip">0.0001525</constant>
+        <constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
+        <constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
+        <constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
         <constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
-        <constant name="EcalBarrelEnergyFactors">0.00648596690341 0.0131746235626</constant>
-        <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
-        <constant name="EcalRingEnergyFactors">0.00600726928777 0.012202268788</constant>
-        <constant name="PandoraEcalToMip">149.254</constant>
-        <constant name="PandoraHcalToMip">35.3357</constant>
+        <constant name="MuonCalibration">56.7</constant>
+        <constant name="PandoraEcalToMip">153.846</constant>
+        <constant name="PandoraHcalToMip">42.1941</constant>
         <constant name="PandoraMuonToMip">10.3093</constant>
         <constant name="PandoraEcalToEMScale">1.0</constant>
         <constant name="PandoraHcalToEMScale">1.0</constant>
-        <constant name="PandoraEcalToHadBarrelScale">1.20700253651</constant>
-        <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-        <constant name="PandoraHcalToHadScale">1.02821419758</constant>
+        <constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
+        <constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+        <constant name="PandoraHcalToHadScale">1.0518169704</constant>
+        <constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
         <constant name="EcalTechnology" value="ScEcal" />
         <constant name="HcalTechnology" value="SDHcal" />
         <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
@@ -1113,7 +1115,7 @@
         <!--name of the part of the cellID that holds the layer-->
         <parameter name="CellIDLayerString" type="string">layer</parameter>
         <!--Calibration coefficients for MUON-->
-        <parameter name="CalibrMUON" type="FloatVec">56.7</parameter>
+        <parameter name="CalibrMUON" type="FloatVec">${MuonCalibration}</parameter>
         <!-- maximum hit energy for a MUON hit -->
         <parameter name="MaxHitEnergyMUON" type="float">2.0</parameter>
         <!--MUON Collection Names-->
@@ -1147,22 +1149,22 @@
         <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
         <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
         <!-- Calibration constants -->
-        <parameter name="ECalToMipCalibration">149.254</parameter>
-        <parameter name="HCalToMipCalibration">35.3357</parameter>
-        <parameter name="MuonToMipCalibration">10.3093</parameter>
+        <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+        <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+        <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
         <parameter name="ECalMipThreshold" type="float">0.5</parameter>
         <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-        <parameter name="ECalToEMGeVCalibration">1.0</parameter>
-        <parameter name="HCalToEMGeVCalibration">1.0</parameter>
-        <parameter name="ECalToHadGeVCalibrationBarrel">1.20700253651</parameter>
-        <parameter name="ECalToHadGeVCalibrationEndCap">1.20700253651</parameter>
-        <parameter name="HCalToHadGeVCalibration">1.02821419758</parameter>
+        <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+        <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+        <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+        <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
         <parameter name="DigitalMuonHits" type="int">0</parameter>
         <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
-        <parameter name="SoftwareCompensationWeights" type="FloatVec">1.53608 0.0020365 -3.84416e-05 -0.0932101 -0.00354252 2.32054e-05 0.924933 1.25159 -0.0447545</parameter>
+        <parameter name="SoftwareCompensationWeights" type="FloatVec">${PandoraSoftwareCompensationWeights}</parameter>
         <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0 2 5 7.5 9.5 13 16 20 23.5 28</parameter>
         <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
-        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">100</parameter>
+        <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
         <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
         <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
         <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed missing calibration constants in all calibration files (all models)
  - missing calibration constant for muon
  - missing calibration constant for soft comp weights
- Fixed missing reference to calibration constants in PandoraPFA processor
- Updated calibration constants for all ILD_l/s5 variants
- Re-generated production steering files

ENDRELEASENOTES