### PR TITLE
Distilled PFO : wrong input collection

### DIFF
--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -81,7 +81,7 @@
 
 
   <processor name="MyDistilledPFOCreator" type="DistilledPFOCreator">
-    <parameter name="InputParticleCollectionName1" value="PandoraPFOsWithoutIsoLep" />
+    <parameter name="InputParticleCollectionName1" value="PandoraPFOs" />
     <parameter name="InputParticleCollectionName2" value="GammaGammaParticles" />
     <parameter name="Printing" value="0" />
     <parameter name="OutputParticleCollectionName" value="DistilledPFOs" />


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed collection name for distilled PFO creation (was PandoraPFOsWithoutLeptons instead of PandoraPFOs)

ENDRELEASENOTES