### PR TITLE
DST and REC file updates

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.xml
@@ -31,3 +31,7 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsHCal">HCalBarrelRPCHits HCalEndcapRPCHits HCalECRingRPCHits</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
@@ -26,3 +26,7 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
@@ -31,3 +31,9 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsECal">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd</constant>
+<constant name="DropCollectionsHCal">HCalBarrelRPCHits HCalEndcapRPCHits HCalECRingRPCHits</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>
+

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
@@ -26,3 +26,8 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsECal">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd</constant>
+<constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -31,3 +31,8 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsECal">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
+<constant name="DropCollectionsHCal">HCalBarrelRPCHits HCalEndcapRPCHits HCalECRingRPCHits</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
@@ -26,3 +26,8 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsECal">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
+<constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.xml
@@ -31,3 +31,7 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsHCal">HCalBarrelRPCHits HCalEndcapRPCHits HCalECRingRPCHits</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
@@ -26,3 +26,7 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
@@ -31,3 +31,8 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsECal">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd</constant>
+<constant name="DropCollectionsHCal">HCalBarrelRPCHits HCalEndcapRPCHits HCalECRingRPCHits</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
@@ -26,3 +26,8 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsECal">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd</constant>
+<constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -31,3 +31,8 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsECal">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
+<constant name="DropCollectionsHCal">HCalBarrelRPCHits HCalEndcapRPCHits HCalECRingRPCHits</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
@@ -26,3 +26,8 @@
 
 <!-- Pandora settings file -->
 <constant name="PandoraSettingsFile" value="PandoraSettings/PandoraSettingsDefault_sdhcal.xml" />
+
+<!-- Additonal collection names to drop from the REC file -->
+<constant name="DropCollectionsECal">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
+<constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
+<constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -225,6 +225,9 @@
       ${RECOutputFile}
     </parameter>
     <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
+    <parameter name="DropCollectionNames" type="StringVec"> 
+      ${AdditionalDropCollectionsREC} 
+    </parameter>
     <!--parameter name="SplitFileSizekB" type="int" value="1992294"/-->
   </processor>
   <processor name="DSTOutput" type="LCIOOutputProcessor">
@@ -242,6 +245,9 @@
       LCRelation
       Track 
       LCFloatVec      
+    </parameter>
+    <parameter name="DropCollectionNames" type="StringVec">
+      PandoraPFANewStartVertices
     </parameter>
     <parameter name="FullSubsetCollections" type="StringVec" value="MCParticlesSkimmed"/>
     <parameter name="KeepCollectionNames" type="StringVec"> 

--- a/StandardConfig/production/ParticleFlow/PandoraPFA.xml
+++ b/StandardConfig/production/ParticleFlow/PandoraPFA.xml
@@ -20,6 +20,8 @@
     <parameter name="ProngVertexCollections" type="StringVec">ProngVertices</parameter>
     <parameter name="SplitVertexCollections" type="StringVec">SplitVertices</parameter>
     <parameter name="V0VertexCollections" type="StringVec">V0Vertices</parameter>
+    <parameter name="StartVertexCollectionName" type="string">PandoraPFANewStartVertices</parameter>
+    <parameter name="StartVertexAlgorithmName" type="string">PandoraPFANew</parameter>
     <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
     <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
     <!-- Calibration constants -->


### PR DESCRIPTION

BEGINRELEASENOTES
- DST output 
  - Drop the PandoraPFANewStartVertices collection
- REC output
  - Drop sim calorimeter hit collection depending on the hybrid technology in use.
  - E.g : drop ScECal and SDHCal hits if we use SiECal and AHCal in the reconstruction
- Marlin Pandora settings
  - Explicit the settings for vertex collection and vertex algorithm name
 
ENDRELEASENOTES