### PR TITLE
Updated calibration parameters of SDHCAL

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
@@ -14,9 +14,9 @@
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.07045526314</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.07045526314</constant>
-<constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.20499007655</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
+<constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.78321 -0.0515853 0.000555338 -0.0858048 0.00546042 -0.000151165 0.0601101 0.069058 -0.113743</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->

--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
@@ -30,7 +30,6 @@
 <!-- Additonal collection names to drop from the REC file -->
 <constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
 <constant name="AdditionalDropCollectionsREC">${DropCollectionsHCal}</constant>
-<<<<<<< c939fc077325e089ec52813dc83cd72d05c24b71
 
 <!-- dEdX error factor depends on large/small detector flavor -->
 <constant name="dEdXErrorFactor">7.55</constant>
@@ -59,5 +58,3 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
-=======
->>>>>>> Updated calibration parameters of SDHCAL

--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
@@ -4,7 +4,7 @@
 <constant name="EcalBarrelMip">0.0001575</constant>
 <constant name="EcalEndcapMip">0.0001575</constant>
 <constant name="EcalRingMip">0.0001575</constant>
-<constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
+<constant name="SDHcalEnergyFactors">0.0367023 0.0745279 0.363042</constant>
 <constant name="EcalBarrelEnergyFactors">0.00641222630095 0.0130248379264</constant>
 <constant name="EcalEndcapEnergyFactors">0.0066862777075 0.0135815049851</constant>
 <constant name="EcalRingEnergyFactors">0.0066862777075 0.0135815049851</constant>
@@ -30,6 +30,7 @@
 <!-- Additonal collection names to drop from the REC file -->
 <constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
 <constant name="AdditionalDropCollectionsREC">${DropCollectionsHCal}</constant>
+<<<<<<< c939fc077325e089ec52813dc83cd72d05c24b71
 
 <!-- dEdX error factor depends on large/small detector flavor -->
 <constant name="dEdXErrorFactor">7.55</constant>
@@ -58,3 +59,5 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
+=======
+>>>>>>> Updated calibration parameters of SDHCAL

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
@@ -4,7 +4,7 @@
 <constant name="EcalBarrelMip">0.0001525</constant>
 <constant name="EcalEndcapMip">0.0001525</constant>
 <constant name="EcalRingMip">0.0001525</constant>
-<constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
+<constant name="SDHcalEnergyFactors">0.0367023 0.0745279 0.363042</constant>
 <constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
 <constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
 <constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
@@ -14,9 +14,9 @@
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
-<constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.20499007655</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
+<constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
@@ -31,7 +31,6 @@
 <constant name="DropCollectionsECal">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
 <constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
 <constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>
-<<<<<<< c939fc077325e089ec52813dc83cd72d05c24b71
 
 <!-- dEdX error factor depends on large/small detector flavor -->
 <constant name="dEdXErrorFactor">7.55</constant>
@@ -60,5 +59,3 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
-=======
->>>>>>> Updated calibration parameters of SDHCAL

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
@@ -4,7 +4,7 @@
 <constant name="EcalBarrelMip">0.0001525</constant>
 <constant name="EcalEndcapMip">0.0001525</constant>
 <constant name="EcalRingMip">0.0001525</constant>
-<constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
+<constant name="SDHcalEnergyFactors">0.0367023 0.0745279 0.363042</constant>
 <constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
 <constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
 <constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
@@ -14,9 +14,9 @@
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
-<constant name="PandoraHcalToHadScale">1.02821419758</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.20499007655</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
+<constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
@@ -31,6 +31,7 @@
 <constant name="DropCollectionsECal">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
 <constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
 <constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>
+<<<<<<< c939fc077325e089ec52813dc83cd72d05c24b71
 
 <!-- dEdX error factor depends on large/small detector flavor -->
 <constant name="dEdXErrorFactor">7.55</constant>
@@ -59,3 +60,5 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
+=======
+>>>>>>> Updated calibration parameters of SDHCAL

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
@@ -14,9 +14,9 @@
 <constant name="PandoraMuonToMip">10.5263</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.06504826673</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
-<constant name="PandoraHcalToHadScale">1.04116630643</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.20499007655</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
+<constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.67738 -0.0324571 0.000211756 -0.0652524 0.00258787 -4.47897e-05 0.057609 0.0659326 -0.0757052</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
@@ -4,7 +4,7 @@
 <constant name="EcalBarrelMip">0.0001575</constant>
 <constant name="EcalEndcapMip">0.0001575</constant>
 <constant name="EcalRingMip">0.0001575</constant>
-<constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
+<constant name="SDHcalEnergyFactors">0.0367023 0.0745279 0.363042</constant>
 <constant name="EcalBarrelEnergyFactors">0.00639206743282 0.0129838902153</constant>
 <constant name="EcalEndcapEnergyFactors">0.00677453657324 0.0137607808509</constant>
 <constant name="EcalRingEnergyFactors">0.00677453657324 0.0137607808509</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
@@ -14,9 +14,9 @@
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
-<constant name="PandoraHcalToHadScale">1.0518169704</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.20499007655</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
+<constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
@@ -31,7 +31,6 @@
 <constant name="DropCollectionsECal">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd</constant>
 <constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
 <constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>
-<<<<<<< c939fc077325e089ec52813dc83cd72d05c24b71
 
 <!-- dEdX error factor depends on large/small detector flavor -->
 <constant name="dEdXErrorFactor">8.53</constant>
@@ -60,5 +59,3 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
-=======
->>>>>>> Updated calibration parameters of SDHCAL

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
@@ -7,7 +7,7 @@
 <constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
 <constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
 <constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
-<constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
+<constant name="SDHcalEnergyFactors">0.0367023 0.0745279 0.363042</constant>
 <constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">153.846</constant>
 <constant name="PandoraHcalToMip">42.1941</constant>
@@ -31,6 +31,7 @@
 <constant name="DropCollectionsECal">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd</constant>
 <constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
 <constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>
+<<<<<<< c939fc077325e089ec52813dc83cd72d05c24b71
 
 <!-- dEdX error factor depends on large/small detector flavor -->
 <constant name="dEdXErrorFactor">8.53</constant>
@@ -59,3 +60,5 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
+=======
+>>>>>>> Updated calibration parameters of SDHCAL

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
@@ -14,9 +14,9 @@
 <constant name="PandoraMuonToMip">10.3093</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
-<constant name="PandoraHcalToHadScale">1.0518169704</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.20499007655</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
+<constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
@@ -31,7 +31,6 @@
 <constant name="DropCollectionsECal">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
 <constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
 <constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>
-<<<<<<< c939fc077325e089ec52813dc83cd72d05c24b71
 
 <!-- dEdX error factor depends on large/small detector flavor -->
 <constant name="dEdXErrorFactor">8.53</constant>
@@ -60,5 +59,3 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
-=======
->>>>>>> Updated calibration parameters of SDHCAL

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
@@ -7,7 +7,7 @@
 <constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
 <constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
 <constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
-<constant name="SDHcalEnergyFactors">0.0490334 0.106432 0.522787</constant>
+<constant name="SDHcalEnergyFactors">0.0367023 0.0745279 0.363042</constant>
 <constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">153.846</constant>
 <constant name="PandoraHcalToMip">42.1941</constant>
@@ -31,6 +31,7 @@
 <constant name="DropCollectionsECal">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
 <constant name="DropCollectionsHCal">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>
 <constant name="AdditionalDropCollectionsREC">${DropCollectionsECal} ${DropCollectionsHCal}</constant>
+<<<<<<< c939fc077325e089ec52813dc83cd72d05c24b71
 
 <!-- dEdX error factor depends on large/small detector flavor -->
 <constant name="dEdXErrorFactor">8.53</constant>
@@ -59,3 +60,5 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
+=======
+>>>>>>> Updated calibration parameters of SDHCAL


### PR DESCRIPTION

BEGINRELEASENOTES
- The SDHCAL parameters for linear energy function and hadronic energy related parameters
in PandoraPFA are updated based the new calibration for ILD_l5_o2_v02 and ILD_l5_o4_v02. 

ENDRELEASENOTES