### PR TITLE
Dst and relations collections

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.xml
@@ -63,3 +63,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">EcalBarrelCollection EcalEndcapRingCollection EcalEndcapsCollection</constant>
+<constant name="HCalSimHitCollections">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
@@ -58,3 +58,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">EcalBarrelCollection EcalEndcapRingCollection EcalEndcapsCollection</constant>
+<constant name="HCalSimHitCollections">HCalBarrelRPCHits HCalECRingRPCHits HCalEndcapRPCHits</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
@@ -64,3 +64,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd EcalEndcapRingCollection</constant>
+<constant name="HCalSimHitCollections">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
@@ -59,3 +59,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd EcalEndcapRingCollection</constant>
+<constant name="HCalSimHitCollections">HCalBarrelRPCHits HCalECRingRPCHits HCalEndcapRPCHits</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -64,3 +64,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd EcalEndcapRingCollection</constant>
+<constant name="HCalSimHitCollections">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
@@ -59,3 +59,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd EcalEndcapRingCollection</constant>
+<constant name="HCalSimHitCollections">HCalBarrelRPCHits HCalECRingRPCHits HCalEndcapRPCHits</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.xml
@@ -63,3 +63,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">EcalBarrelCollection EcalEndcapRingCollection EcalEndcapsCollection</constant>
+<constant name="HCalSimHitCollections">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
@@ -58,3 +58,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">EcalBarrelCollection EcalEndcapRingCollection EcalEndcapsCollection</constant>
+<constant name="HCalSimHitCollections">HCalBarrelRPCHits HCalECRingRPCHits HCalEndcapRPCHits</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
@@ -64,3 +64,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd EcalEndcapRingCollection</constant>
+<constant name="HCalSimHitCollections">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
@@ -59,3 +59,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">ECalBarrelSiHitsEven ECalBarrelSiHitsOdd ECalEndcapSiHitsEven ECalEndcapSiHitsOdd EcalEndcapRingCollection</constant>
+<constant name="HCalSimHitCollections">HCalBarrelRPCHits HCalECRingRPCHits HCalEndcapRPCHits</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -64,3 +64,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd EcalEndcapRingCollection</constant>
+<constant name="HCalSimHitCollections">HcalBarrelRegCollection HcalEndcapRingCollection HcalEndcapsCollection</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
@@ -59,3 +59,7 @@
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_19GeVP_clusterinfo.weights.xml
   HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_s5_20GeVP_clusterinfo.weights.xml
 </constant>
+
+<!-- SimCalorimeterHit collection names. Necessary to deal with hybrid reconstruction -->
+<constant name="ECalSimHitCollections">ECalBarrelScHitsEven ECalBarrelScHitsOdd ECalEndcapScHitsEven ECalEndcapScHitsOdd EcalEndcapRingCollection</constant>
+<constant name="HCalSimHitCollections">HCalBarrelRPCHits HCalECRingRPCHits HCalEndcapRPCHits</constant>

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -180,20 +180,21 @@
     <!-- same for the calos: Simulated calo hits (has the connection to MCParticles) -->
     <parameter name="SimCaloHitCollections" type="StringVec" lcioInType="SimCalorimeterHit">
       BeamCalCollection
-      EcalBarrelCollection
-      EcalEndcapsCollection
-      EcalEndcapRingCollection
-      HcalBarrelRegCollection
-      HcalEndcapsCollection
-      HcalEndcapRingCollection
       LHCalCollection
       LumiCalCollection
+      ${ECalSimHitCollections}
+      ${HCalSimHitCollections}
       YokeBarrelCollection
       YokeEndcapsCollection
     </parameter> 
     <!-- Connections from calo hist (connected to clusters) tp sim calo hits  (connects to MC particle) -->
     <parameter name="SimCalorimeterHitRelationNames" type="StringVec" lcioInType="LCRelation">
-      RelationCaloHit
+      EcalBarrelRelationsSimRec
+      EcalEndcapRingRelationsSimRec
+      EcalEndcapsRelationsSimRec
+      HcalBarrelRelationsSimRec
+      HcalEndcapRingRelationsSimRec
+      HcalEndcapsRelationsSimRec
       RelationLHcalHit
       RelationMuonHit
       RelationLcalHit

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -228,6 +228,9 @@
       MCTruthMarlinTrkTracksLink
       MarlinTrkTracksMCTruthLink
       RecoMCTruthLink
+      MCTruthRecoLink
+      MCTruthClusterLink
+      ClusterMCTruthLink
     </parameter>
     <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
     <!--parameter name="SplitFileSizekB" type="int" value="1992294"/-->

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -223,7 +223,7 @@
     </parameter>
     <parameter name="FullSubsetCollections" type="StringVec" value="MCParticlesSkimmed"/>
     <parameter name="KeepCollectionNames" type="StringVec"> 
-      MCParticlesSkimmed 
+      MCParticle
       MarlinTrkTracks
       MCTruthMarlinTrkTracksLink
       MarlinTrkTracksMCTruthLink


### PR DESCRIPTION

BEGINRELEASENOTES
- Changed MCParticlesSkimmed to MCParticle collection in DST
- Added 3 more relation collections to DST :  MCTruthRecoLink, MCTruthClusterLink and ClusterMCTruthLink
- Added two new constants for sim calo hit collections (to deal with hybrid models)
- Corrected wrong input collection names in MCThruthLinker processor : SimCaloHitCollections and SimCalorimeterHitRelationNames

ENDRELEASENOTES