### PR TITLE
relax MinChi2ProbForSiliconTracks in FullLDCTracking

### DIFF
--- a/StandardConfig/production/Tracking/TrackingReco.xml
+++ b/StandardConfig/production/Tracking/TrackingReco.xml
@@ -369,6 +369,8 @@
     <parameter name="SITHitCollection" type="string" lcioInType="TrackerHit"> SITTrackerHits </parameter>
     <!--Cut on distance between track and SIT hits-->
     <parameter name="SITHitToTrackDistance" type="float">2 </parameter>
+    <!--Minimum Chi-squared P value allowed for Silicon Tracks.-->
+    <parameter name="MinChi2ProbForSiliconTracks" type="double">0.00001 </parameter>
     <!--Si Track Collection-->
     <parameter name="SiTracks" type="string" lcioInType="Track">SubsetTracks </parameter>
     <!--Si Track to Collection-->


### PR DESCRIPTION

BEGINRELEASENOTES
- relax MinChi2ProbForSiliconTracks in FullLDCTracking
    - should increase tracking efficiency in forward region
    - otherwise found forward tracks w/ large chi2/ndf are droped

ENDRELEASENOTES