### PR TITLE
BeamCal calibration update

### DIFF
--- a/StandardConfig/production/CaloDigi/FcalDigi.xml
+++ b/StandardConfig/production/CaloDigi/FcalDigi.xml
@@ -12,7 +12,7 @@
     <parameter name="CellIDLayerString" type="string"> layer </parameter>
 
     <!--Calibration coefficients for LCAL-->
-    <parameter name="CalibrFCAL" type="FloatVec">72.</parameter>
+    <parameter name="CalibrFCAL" type="FloatVec">${BeamCalCalibrationFactor}</parameter>
     <!--LCAL Collection Names-->
     <parameter name="FCALCollections" type="StringVec">BeamCalCollection</parameter>
     <!--LCAL Collection of real Hits-->

--- a/StandardConfig/production/HighLevelReco/BeamCalReco.xml
+++ b/StandardConfig/production/HighLevelReco/BeamCalReco.xml
@@ -46,7 +46,7 @@
     <!--How many layers are used for shower fitting-->
     <parameter name="NShowerCountingLayers" type="int">3 </parameter>
     <!--Multiply deposit energy by this factor to account for sampling fraction-->
-    <parameter name="LinearCalibrationFactor" type="double">72. </parameter>
+    <parameter name="LinearCalibrationFactor" type="double">${BeamCalCalibrationFactor}</parameter>
     <!--Weighting constant to use in logarithmic weighting of hits, if negative energy weighting is used-->
     <parameter name="LogWeightingConstant" type="double">-1. </parameter>
     <!--Maximum Distance between primary tower and neighbours to put into one cluster-->

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -43,6 +43,8 @@
     <constant name="OverlayParametersFile" value="Overlay/OverlayParameters${CMSEnergy}GeV.xml" />
     <!--Whether to run the BeamCal reconstruction-->
     <constant name="RunBeamCalReco" value="true" />
+    <!--The BeamCal calibration constant, sim hit energy to calibrated calo hit energy-->
+    <constant name="BeamCalCalibrationFactor">79.6</constant>
     
     <!-- ***** Input files constants ***** -->    
     <!-- Special Beamcal overlay background file -->


### PR DESCRIPTION
BEGINRELEASENOTES
- BeamCal calibration:
   - moved calibration constant of BeamCal in a Marlin constant
   - use Marlin constant in the BeamCal digitizer and the BeamCalClusterReco
   - energy calibration constant updated to 79.6 (old was 72)

ENDRELEASENOTES