### PR TITLE
Default model fix

### DIFF
--- a/.travis-ci.d/test.sh
+++ b/.travis-ci.d/test.sh
@@ -8,7 +8,7 @@ cd /Package/StandardConfig/production
 ##
 ## Test DDSim for our current detector models
 ##
-for detector in ILD_l5_v02 ILD_s5_v02
+for detector in ILD_l5_v02
 do
   echo "-- Running DDSim ${detector} ..."
   ddsim \
@@ -41,9 +41,9 @@ done
 ##
 ## Test Marlin reconstruction for our current detector models 
 ##
-for largeOrSmall in l5 s5
+for largeOrSmall in l5
 do
-  for detectorOption in o1 o2
+  for detectorOption in o1
   do
     simDetector="ILD_${largeOrSmall}_v02"
     recDetector="ILD_${largeOrSmall}_${detectorOption}_v02"

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -28,7 +28,7 @@
     <!-- The lcgeo directory where to look for the ILD model -->
     <constant name="lcgeo_DIR" value="/path/to/lcgeo_DIR" />
     <!-- ILD detector model -->
-    <constant name="DetectorModel" value="ILD_l5_o1_v02" />
+    <constant name="DetectorModel" value="None_Please_specify_one" />
     <!-- The full compact file name -->
     <constant name="CompactFile" value="${lcgeo_DIR}/ILD/compact/${DetectorModel}/${DetectorModel}.xml" />
     <!-- ILD calibration file -->


### PR DESCRIPTION

BEGINRELEASENOTES
- TravisCI
    - Restrict simulation and reconstruction to ILD_l5_o1_v02 to avoid timeout in TravisCI
- MarlinStdReco.xml
    - Changed default `DetectorModel` constant to none causing error if user don't specify it

ENDRELEASENOTES