### PR TITLE
Beam size parameters update

### DIFF
--- a/.travis-ci.d/test.sh
+++ b/.travis-ci.d/test.sh
@@ -41,9 +41,9 @@ done
 ##
 ## Test Marlin reconstruction for our current detector models 
 ##
-for largeOrSmall in l5
+for largeOrSmall in l5 s5
 do
-  for detectorOption in o1
+  for detectorOption in o1 o2
   do
     simDetector="ILD_${largeOrSmall}_v02"
     recDetector="ILD_${largeOrSmall}_${detectorOption}_v02"
@@ -54,6 +54,7 @@ do
     	--constant.lcgeo_DIR=$lcgeo_DIR \
       --constant.DetectorModel=${recDetector} \
       --constant.OutputBaseName=${outputBaseName} \
+      --constant.RunBeamCalReco=false \
       --global.LCIOInputFiles=bbudsc_3evt_SIM_test_${simDetector}.slcio > travis-ci.log 2>&1
     
     marlinStatus=$?

--- a/.travis-ci.d/test.sh
+++ b/.travis-ci.d/test.sh
@@ -6,83 +6,73 @@ source $ILCSOFT/init_ilcsoft.sh
 cd /Package/StandardConfig/production
 
 ##
-## Test DDSim for our current detector models
+## Test DDSim
 ##
-for detector in ILD_l5_v02 ILD_s5_v02
+echo "-- Running DDSim ${SIM_MODEL} ..."
+ddsim \
+  --inputFiles Examples/bbudsc_3evt/bbudsc_3evt.stdhep \
+  --outputFile bbudsc_3evt_SIM_test_${SIM_MODEL}.slcio \
+  --compactFile $lcgeo_DIR/ILD/compact/${SIM_MODEL}/${SIM_MODEL}.xml \
+  --steeringFile ddsim_steer.py > travis-ci.log 2>&1
+
+ddsimStatus=$?
+
+if [[ $ddsimStatus != 0 ]]
+then
+  cat travis-ci.log
+  echo "-- ERROR - DDSim ${SIM_MODEL}: 3 events test failed"
+  exit $ddsimStatus
+else
+  echo "-- DDSim ${SIM_MODEL}: test passing !"
+fi
+
+# test presence of output file
+if [ ! -f "bbudsc_3evt_SIM_test_${SIM_MODEL}.slcio" ]
+then
+  ls -lthr
+  echo "-- ERROR - DDSim ${SIM_MODEL}: No output file found (bbudsc_3evt_SIM_test_${SIM_MODEL}.slcio)"
+  exit 1
+fi
+
+
+##
+## Test Marlin reconstruction
+##
+outputBaseName="bbudsc_3evt_RECNoBG_Test_${REC_MODEL}"
+
+echo "-- Running Marlin ${REC_MODEL} no bg ..."
+Marlin MarlinStdReco.xml \
+	--constant.lcgeo_DIR=$lcgeo_DIR \
+  --constant.DetectorModel=${REC_MODEL} \
+  --constant.OutputBaseName=${outputBaseName} \
+  --constant.RunBeamCalReco=false \
+  --global.LCIOInputFiles=bbudsc_3evt_SIM_test_${SIM_MODEL}.slcio > travis-ci.log 2>&1
+
+marlinStatus=$?
+
+if [[ $marlinStatus != 0 ]]
+then
+  cat travis-ci.log
+  echo "-- ERROR - Marlin ${REC_MODEL} no bg: 3 events test failed"
+  exit $marlinStatus
+else
+  echo "-- Marlin ${REC_MODEL} no bg: test passing !"
+fi
+
+# test presence of different output files
+checkFileList="${outputBaseName}_REC.slcio \
+               ${outputBaseName}_DST.slcio \
+               ${outputBaseName}_PfoAnalysis.root \
+               ${outputBaseName}_AIDA.root"
+for checkFile in ${checkFileList}
 do
-  echo "-- Running DDSim ${detector} ..."
-  ddsim \
-    --inputFiles Examples/bbudsc_3evt/bbudsc_3evt.stdhep \
-    --outputFile bbudsc_3evt_SIM_test_${detector}.slcio \
-    --compactFile $lcgeo_DIR/ILD/compact/${detector}/${detector}.xml \
-    --steeringFile ddsim_steer.py > travis-ci.log 2>&1
-
-  ddsimStatus=$?
-
-  if [[ $ddsimStatus != 0 ]]
-  then
-    cat travis-ci.log
-    echo "-- ERROR - DDSim ${detector}: 3 events test failed"
-    exit $ddsimStatus
-  else
-    echo "-- DDSim ${detector}: test passing !"
-  fi
-  
-  # test presence of output file
-  if [ ! -f "bbudsc_3evt_SIM_test_${detector}.slcio" ]
+  if [ ! -f ${checkFile} ]
   then
     ls -lthr
-    echo "-- ERROR - DDSim ${detector}: No output file found (bbudsc_3evt_SIM_test_${detector}.slcio)"
+    echo "-- ERROR - Marlin ${REC_MODEL} no bg: Missing output file ${checkFile}"
     exit 1
+  else
+    echo "-- Marlin ${REC_MODEL} no bg: ${checkFile} present ..."
   fi
 done
 
-
-##
-## Test Marlin reconstruction for our current detector models 
-##
-for largeOrSmall in l5 s5
-do
-  for detectorOption in o1 o2
-  do
-    simDetector="ILD_${largeOrSmall}_v02"
-    recDetector="ILD_${largeOrSmall}_${detectorOption}_v02"
-    outputBaseName="bbudsc_3evt_RECNoBG_Test_${recDetector}"
-    
-    echo "-- Running Marlin ${recDetector} no bg ..."
-    Marlin MarlinStdReco.xml \
-    	--constant.lcgeo_DIR=$lcgeo_DIR \
-      --constant.DetectorModel=${recDetector} \
-      --constant.OutputBaseName=${outputBaseName} \
-      --constant.RunBeamCalReco=false \
-      --global.LCIOInputFiles=bbudsc_3evt_SIM_test_${simDetector}.slcio > travis-ci.log 2>&1
-    
-    marlinStatus=$?
-
-    if [[ $marlinStatus != 0 ]]
-    then
-      cat travis-ci.log
-      echo "-- ERROR - Marlin ${recDetector} no bg: 3 events test failed"
-      exit $marlinStatus
-    else
-      echo "-- Marlin ${recDetector} no bg: test passing !"
-    fi
-    
-    # test presence of different output files
-    checkFileList="${outputBaseName}_REC.slcio \
-                   ${outputBaseName}_DST.slcio \
-                   ${outputBaseName}_PfoAnalysis.root \
-                   ${outputBaseName}_AIDA.root"
-    for checkFile in ${checkFileList}
-    do
-      if [ ! -f ${checkFile} ]
-      then
-        ls -lthr
-        echo "-- ERROR - Marlin ${recDetector} no bg: Missing output file ${checkFile}"
-        exit 1
-      else
-        echo "-- Marlin ${recDetector} no bg: ${checkFile} present ..."
-      fi
-    done
-  done
-done

--- a/.travis-ci.d/test.sh
+++ b/.travis-ci.d/test.sh
@@ -8,7 +8,7 @@ cd /Package/StandardConfig/production
 ##
 ## Test DDSim for our current detector models
 ##
-for detector in ILD_l5_v02
+for detector in ILD_l5_v02 ILD_s5_v02
 do
   echo "-- Running DDSim ${detector} ..."
   ddsim \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 sudo: required
 dist: trusty
 
+env:
+  matrix:
+    - SIM_MODEL=ILD_l5_v02 REC_MODEL=ILD_l5_o1_v02
+    - SIM_MODEL=ILD_s5_v02 REC_MODEL=ILD_s5_o1_v02
+    - SIM_MODEL=ILD_l5_v02 REC_MODEL=ILD_l5_o2_v02
+    - SIM_MODEL=ILD_s5_v02 REC_MODEL=ILD_s5_o2_v02
+
 services:
   - docker
 
@@ -31,7 +38,7 @@ install:
 
 # command to run tests
 script:
-  - docker run -it --name CI_container -v $PKGDIR:/Package -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
+  - docker run -it --name CI_container -e SIM_MODEL=$SIM_MODEL -e REC_MODEL=$REC_MODEL -v $PKGDIR:/Package -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
   - docker exec -it CI_container /bin/bash -c "./Package/.travis-ci.d/test.sh";
 
 # Don't send e-mail notifications

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ ILDConfig is distributed under the [GPLv3 License](http://www.gnu.org/licenses/g
 
 ## StandardConfig
 
-- ./lcgeo_current
-	- current example/standard configuration files for running ddsim and ILDConfig
+- ./production
+	- current example/standard configuration files for running simulation (ddsim) and reconstruction (Marlin) for ILD
 	
-See [./StandardConfig/lcgeo_current/README.md](./StandardConfig/lcgeo_current/README.md) for details.
+See [./StandardConfig/production/README.md](./StandardConfig/production/README.md) for details.
 Following the examples in this file is the quickest way to get started with running iLCSoft for ILD.
 
 ## LCFIPlusConfig

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
@@ -68,9 +68,9 @@
 <constant name="ECalEndcapSimHitCollections">ECalEndcapSiHitsEven ECalEndcapSiHitsOdd</constant>
 <constant name="ECalRingSimHitCollections">EcalEndcapRingCollection</constant>
 
-<constant name="HCalBarrelSimHitCollections">HcalBarrelRegCollection</constant>
-<constant name="HCalEndcapSimHitCollections">HcalEndcapsCollection</constant>
-<constant name="HCalRingSimHitCollections">HcalEndcapRingCollection</constant>
+<constant name="HCalBarrelSimHitCollections">HCalBarrelRPCHits</constant>
+<constant name="HCalEndcapSimHitCollections">HCalEndcapRPCHits</constant>
+<constant name="HCalRingSimHitCollections">HCalECRingRPCHits</constant>
 
 <constant name="ECalSimHitCollections">${ECalBarrelSimHitCollections} ${ECalEndcapSimHitCollections} ${ECalRingSimHitCollections}</constant>
 <constant name="HCalSimHitCollections">${HCalBarrelSimHitCollections} ${HCalEndcapSimHitCollections} ${HCalRingSimHitCollections}</constant>

--- a/StandardConfig/production/Config/Parameters1000GeV.xml
+++ b/StandardConfig/production/Config/Parameters1000GeV.xml
@@ -1,0 +1,11 @@
+
+<!--Overlay background settings-->
+<constant name="ExpectedBgWW" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgWB" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgBW" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgBB" value="Parameter not yet provided. Please update me !" />
+
+<!--Beam size (unit mm)-->
+<constant name="BeamSizeX" value="Parameter not yet provided. Please update me !" />
+<constant name="BeamSizeY" value="Parameter not yet provided. Please update me !" />
+<constant name="BeamSizeZ" value="Parameter not yet provided. Please update me !" />

--- a/StandardConfig/production/Config/Parameters1000GeV.xml
+++ b/StandardConfig/production/Config/Parameters1000GeV.xml
@@ -6,6 +6,7 @@
 <constant name="ExpectedBgBB" value="Parameter not yet provided. Please update me !" />
 
 <!--Beam size (unit mm)-->
+<constant name="LCFIPlusBeamspotConstraint" value="true" />
 <constant name="BeamSizeX" value="Parameter not yet provided. Please update me !" />
 <constant name="BeamSizeY" value="Parameter not yet provided. Please update me !" />
 <constant name="BeamSizeZ" value="Parameter not yet provided. Please update me !" />

--- a/StandardConfig/production/Config/Parameters250GeV.xml
+++ b/StandardConfig/production/Config/Parameters250GeV.xml
@@ -1,0 +1,11 @@
+
+<!--Overlay background settings-->
+<constant name="ExpectedBgWW" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgWB" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgBW" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgBB" value="Parameter not yet provided. Please update me !" />
+
+<!--Beam size (unit mm)-->
+<constant name="BeamSizeX" value="Parameter not yet provided. Please update me !" />
+<constant name="BeamSizeY" value="Parameter not yet provided. Please update me !" />
+<constant name="BeamSizeZ" value="Parameter not yet provided. Please update me !" />

--- a/StandardConfig/production/Config/Parameters250GeV.xml
+++ b/StandardConfig/production/Config/Parameters250GeV.xml
@@ -6,6 +6,7 @@
 <constant name="ExpectedBgBB" value="Parameter not yet provided. Please update me !" />
 
 <!--Beam size (unit mm)-->
+<constant name="LCFIPlusBeamspotConstraint" value="true" />
 <constant name="BeamSizeX" value="Parameter not yet provided. Please update me !" />
 <constant name="BeamSizeY" value="Parameter not yet provided. Please update me !" />
 <constant name="BeamSizeZ" value="Parameter not yet provided. Please update me !" />

--- a/StandardConfig/production/Config/Parameters350GeV.xml
+++ b/StandardConfig/production/Config/Parameters350GeV.xml
@@ -1,0 +1,11 @@
+
+<!--Overlay background settings-->
+<constant name="ExpectedBgWW" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgWB" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgBW" value="Parameter not yet provided. Please update me !" />
+<constant name="ExpectedBgBB" value="Parameter not yet provided. Please update me !" />
+
+<!--Beam size (unit mm)-->
+<constant name="BeamSizeX" value="Parameter not yet provided. Please update me !" />
+<constant name="BeamSizeY" value="Parameter not yet provided. Please update me !" />
+<constant name="BeamSizeZ" value="Parameter not yet provided. Please update me !" />

--- a/StandardConfig/production/Config/Parameters350GeV.xml
+++ b/StandardConfig/production/Config/Parameters350GeV.xml
@@ -6,6 +6,7 @@
 <constant name="ExpectedBgBB" value="Parameter not yet provided. Please update me !" />
 
 <!--Beam size (unit mm)-->
+<constant name="LCFIPlusBeamspotConstraint" value="true" />
 <constant name="BeamSizeX" value="Parameter not yet provided. Please update me !" />
 <constant name="BeamSizeY" value="Parameter not yet provided. Please update me !" />
 <constant name="BeamSizeZ" value="Parameter not yet provided. Please update me !" />

--- a/StandardConfig/production/Config/Parameters500GeV.xml
+++ b/StandardConfig/production/Config/Parameters500GeV.xml
@@ -6,6 +6,7 @@
 <constant name="ExpectedBgBB" value="0.35063" />
 
 <!--Beam size (unit mm)-->
+<constant name="LCFIPlusBeamspotConstraint" value="true" />
 <constant name="BeamSizeX" value="303.e-6" />
 <constant name="BeamSizeY" value="2.38e-6" />
 <constant name="BeamSizeZ" value="196.e-3" />

--- a/StandardConfig/production/Config/Parameters500GeV.xml
+++ b/StandardConfig/production/Config/Parameters500GeV.xml
@@ -1,0 +1,12 @@
+
+<!--Overlay background settings-->
+<constant name="ExpectedBgWW" value="0.211" />
+<constant name="ExpectedBgWB" value="0.24605" />
+<constant name="ExpectedBgBW" value="0.243873" />
+<constant name="ExpectedBgBB" value="0.35063" />
+
+<!--Beam size (unit mm)-->
+<constant name="BeamSizeX" value="303.e-6" />
+<constant name="BeamSizeY" value="2.38e-6" />
+<constant name="BeamSizeZ" value="196.e-3" />
+

--- a/StandardConfig/production/Config/ParametersUnknownGeV.xml
+++ b/StandardConfig/production/Config/ParametersUnknownGeV.xml
@@ -1,0 +1,11 @@
+
+<!--Overlay background settings-->
+<constant name="ExpectedBgWW" value="Undefined energy for overlay background" />
+<constant name="ExpectedBgWB" value="Undefined energy for overlay background" />
+<constant name="ExpectedBgBW" value="Undefined energy for overlay background" />
+<constant name="ExpectedBgBB" value="Undefined energy for overlay background" />
+
+<!--Beam size (unit mm)-->
+<constant name="BeamSizeX" value="0" />
+<constant name="BeamSizeY" value="0" />
+<constant name="BeamSizeZ" value="0" />

--- a/StandardConfig/production/Config/ParametersUnknownGeV.xml
+++ b/StandardConfig/production/Config/ParametersUnknownGeV.xml
@@ -6,6 +6,7 @@
 <constant name="ExpectedBgBB" value="0" />
 
 <!--Beam size (unit mm)-->
+<constant name="LCFIPlusBeamspotConstraint" value="false" />
 <constant name="BeamSizeX" value="0" />
 <constant name="BeamSizeY" value="0" />
 <constant name="BeamSizeZ" value="0" />

--- a/StandardConfig/production/Config/ParametersUnknownGeV.xml
+++ b/StandardConfig/production/Config/ParametersUnknownGeV.xml
@@ -1,9 +1,9 @@
 
 <!--Overlay background settings-->
-<constant name="ExpectedBgWW" value="Undefined energy for overlay background" />
-<constant name="ExpectedBgWB" value="Undefined energy for overlay background" />
-<constant name="ExpectedBgBW" value="Undefined energy for overlay background" />
-<constant name="ExpectedBgBB" value="Undefined energy for overlay background" />
+<constant name="ExpectedBgWW" value="0" />
+<constant name="ExpectedBgWB" value="0" />
+<constant name="ExpectedBgBW" value="0" />
+<constant name="ExpectedBgBB" value="0" />
 
 <!--Beam size (unit mm)-->
 <constant name="BeamSizeX" value="0" />

--- a/StandardConfig/production/Documentation/HowToRunBgOverlay.md
+++ b/StandardConfig/production/Documentation/HowToRunBgOverlay.md
@@ -147,7 +147,7 @@ and get the simulation output file as *bbudsc_3evt.slcio*, to be used as input f
 
 ## Running the reconstruction with the overlay background
 
-To run the reconstruction with the background overlay, you need to specify which CMS energy you want to use and where the simulated background files are located. The expected number of background events for each CMS energy can be found in the *Overlay* directory in different files. Assuming that all the produced background samples located in the directory 
+To run the reconstruction with the background overlay, you need to specify which CMS energy you want to use and where the simulated background files are located. The expected number of background events for each CMS energy can be found in the *Config* directory in different files. Assuming that all the produced background samples located in the directory 
 
 */nfs/dust/ilc/group/ild/eteremi/SIM/bg/*
 
@@ -174,4 +174,6 @@ This outputs the following output files :
 - bbudsc_3evt_REC.slcio : the REC file with all reconstructed collections
 - bbudsc_3evt_DST.slcio : the DSL file with the collection suitable for physics analysis only
 - bbudsc_3evt_PfoAnalysis.root : A root file with useful information on reconstructed particles for monitoring, calibration and uds performance
+
+Note that the ee pair background overlay is not performed in the BeamCal as the BeamCal reconstruction already take this into account.
 

--- a/StandardConfig/production/Documentation/ProductionSettings.md
+++ b/StandardConfig/production/Documentation/ProductionSettings.md
@@ -71,6 +71,6 @@ Examples on how to simulate background events with these parameters can be found
 ## 2. Reconstruction parameters
 
 To reconstruct events we assume we have 1 source of physics event (e+e- collision) and a set of background (all backgrounds being WW, WB, BW, BB and pair).
-The number of background events to be overlaid on the physics event is the only reconstruction parameter in this case. All these values can be found in the *Overlay* directory and depend on the CMS energy.
+The number of background events to be overlaid on the physics event is the only reconstruction parameter in this case. All these values can be found in the *Config* directory and depend on the CMS energy.
 
 Examples on how to run the reconstruction with the background overlay can be found in the document [HowToRunBgOverlay.md](HowToRunBgOverlay.md) in the same directory.

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -255,7 +255,7 @@
     <parameter name="PrimaryVertexFinder.TrackMaxZ0" type="double" value="20." />
     <parameter name="PrimaryVertexFinder.TrackMinVtxFtdHits" type="int" value="1" />
     <parameter name="PrimaryVertexFinder.Chi2Threshold" type="double" value="25." />
-    <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool" value="1" />
+    <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool" value="${LCFIPlusBeamspotConstraint}" />
     <parameter name="PrimaryVertexFinder.BeamspotSmearing" type="bool" value="0" />
     <!-- parameters for secondary vertex finder -->
     <parameter name="BuildUpVertex.TrackMaxD0" type="double" value="10." />

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -142,7 +142,7 @@
   <processor name="MyRecoMCTruthLinker" type="RecoMCTruthLinker">
     <!--links RecontructedParticles to the MCParticle based on number of hits used-->
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING0  </parameter> 
+    <!-- <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING0  </parameter>  -->
     <!--  Input collections: mcparticles, pfos, clusters and tracks 
           PFOs already connect to tracks and clusters, so what we do in this processor is to connect
           tracks and clusters to mcparticles ... 
@@ -231,6 +231,8 @@
     <parameter name="UseTrackerHitRelations" type="bool"> true </parameter>
     <!--If Using Particle Gun Ignore Gen Stat-->
     <parameter name="UsingParticleGun" type="bool"> false </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
   </processor>
 
 
@@ -290,8 +292,6 @@
     <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
     <!--Assumed time resolution per hit in ps-->
     <parameter name="TimeResolution" type="float">0 </parameter>
-    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
   </processor>
   <processor name="TOFEstimators10ps" type="TOFEstimators">
     <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
@@ -301,8 +301,6 @@
     <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
     <!--Assumed time resolution per hit in ps-->
     <parameter name="TimeResolution" type="float">10. </parameter>
-    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
   </processor>
   <processor name="TOFEstimators50ps" type="TOFEstimators">
     <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
@@ -312,11 +310,7 @@
     <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
     <!--Assumed time resolution per hit in ps-->
     <parameter name="TimeResolution" type="float">50 </parameter>
-    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
   </processor>
 
-
-
-
 </group>
+

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -242,9 +242,9 @@
     <parameter name="TrackHitOrdering" type="int" value="1"/> <!-- Track hit ordering: 0=ILD-LOI,SID-DBD, 1=ILD-DBD -->
     <parameter name="PrintEventNumber" type="int" value="0"/> <!-- 0 for not printing event number, n for printing every n events -->
     <!-- IP distribution used in constraint on primary vertex fitting [mm], numbers are from GuineaPig for 5000 GeV -->
-    <parameter name="BeamSizeX" type="float" value="303.e-6"/>
-    <parameter name="BeamSizeY" type="float" value="2.38e-6"/>
-    <parameter name="BeamSizeZ" type="float" value="196.e-3"/>
+    <parameter name="BeamSizeX" type="float" value="${BeamSizeX}"/>
+    <parameter name="BeamSizeY" type="float" value="${BeamSizeY}"/>
+    <parameter name="BeamSizeZ" type="float" value="${BeamSizeZ}"/>
     <!-- specify input collection names -->
     <parameter name="PFOCollection" type="string" value="PandoraPFOs" />
     <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertex" />

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -53,8 +53,8 @@
     <!-- Geometry model dependant calibration constants from external file -->
     <include ref="${CalibrationFile}" />
     
-    <!-- Parameters for background overlay -->
-    <include ref="${OverlayParametersFile}" />
+    <!-- Energy dependant parameters -->
+    <include ref="${EnergyParametersFile}" />
     
     <!-- Output files constants -->
     <constant name="OutputBaseName" value="StandardReco" />

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -39,8 +39,8 @@
     <constant name="RunOverlay" value="false" />
     <!-- The center of mass energy (unit GeV). Mainly used for background overlay -->
     <constant name="CMSEnergy" value="Unknown" />
-    <!-- The background overlay parameters file to include -->
-    <constant name="OverlayParametersFile" value="Overlay/OverlayParameters${CMSEnergy}GeV.xml" />
+    <!-- The energy dependant parameters file to include -->
+    <constant name="EnergyParametersFile" value="Config/Parameters${CMSEnergy}GeV.xml" />
     <!--Whether to run the BeamCal reconstruction-->
     <constant name="RunBeamCalReco" value="true" />
     <!--The BeamCal calibration constant, sim hit energy to calibrated calo hit energy-->

--- a/StandardConfig/production/Overlay/OverlayParameters1000GeV.xml
+++ b/StandardConfig/production/Overlay/OverlayParameters1000GeV.xml
@@ -1,6 +1,0 @@
-
-
-<constant name="ExpectedBgWW" value="-1" />
-<constant name="ExpectedBgWB" value="-1" />
-<constant name="ExpectedBgBW" value="-1" />
-<constant name="ExpectedBgBB" value="-1" />

--- a/StandardConfig/production/Overlay/OverlayParameters250GeV.xml
+++ b/StandardConfig/production/Overlay/OverlayParameters250GeV.xml
@@ -1,6 +1,0 @@
-
-
-<constant name="ExpectedBgWW" value="-1" />
-<constant name="ExpectedBgWB" value="-1" />
-<constant name="ExpectedBgBW" value="-1" />
-<constant name="ExpectedBgBB" value="-1" />

--- a/StandardConfig/production/Overlay/OverlayParameters350GeV.xml
+++ b/StandardConfig/production/Overlay/OverlayParameters350GeV.xml
@@ -1,6 +1,0 @@
-
-
-<constant name="ExpectedBgWW" value="-1" />
-<constant name="ExpectedBgWB" value="-1" />
-<constant name="ExpectedBgBW" value="-1" />
-<constant name="ExpectedBgBB" value="-1" />

--- a/StandardConfig/production/Overlay/OverlayParameters500GeV.xml
+++ b/StandardConfig/production/Overlay/OverlayParameters500GeV.xml
@@ -1,6 +1,0 @@
-
-
-<constant name="ExpectedBgWW" value="0.211" />
-<constant name="ExpectedBgWB" value="0.24605" />
-<constant name="ExpectedBgBW" value="0.243873" />
-<constant name="ExpectedBgBB" value="0.35063" />

--- a/StandardConfig/production/Overlay/OverlayParametersUnknownGeV.xml
+++ b/StandardConfig/production/Overlay/OverlayParametersUnknownGeV.xml
@@ -1,6 +1,0 @@
-
-
-<constant name="ExpectedBgWW" value="-1" />
-<constant name="ExpectedBgWB" value="-1" />
-<constant name="ExpectedBgBW" value="-1" />
-<constant name="ExpectedBgBB" value="-1" />

--- a/StandardConfig/production/README.md
+++ b/StandardConfig/production/README.md
@@ -31,7 +31,7 @@ Currently you can find the following sub-directories for usual processors :
 
 In addition, you may find the following sub-directories :
 
-- *Overlay* : The gamma gamma overlay and pair background settings (as constants)
+- *Config* : Specific configuration files that may depends on CMS energy or detector models
 - *Calibration* : The calibration constants for the different detector flavors currently under study. Constants are mainly related to energy calibration, dEdX, and particle identification.
 - *Examples* : Example scripts to run 3 ttbar events simulation and reconstruction
 - *Gear* : The geometry files of the (deprecated) GEAR package of the detector geometries currently under study
@@ -84,7 +84,7 @@ This will create the 4 following files :
 - *bbudsc_3evt_DST.slcio* : Output file file containing the collections suited for physics analysis (PFO, cluster, rec hits, etc ...)
 - *bbudsc_3evt_PfoAnalysis.root* : A root file with a simple analysis of produced PFO. It is mainly used to study single particle performance and calibration or JER performances
 
-For single particles reconstruction you may also want to switch of the BeamCal reconstruction (time consuming) if you don't shoot in this region and/or if you have time processing constraints. To do this you can add the argument `--constant.RunBeamCalReco=false`. Example:
+For single particles reconstruction you may also want to switch off the BeamCal reconstruction (time consuming) if you don't shoot in this region and/or if you have time processing constraints. To do this you can add the argument `--constant.RunBeamCalReco=false`. Example:
 
 ```shell
 Marlin MarlinStdReco.xml \


### PR DESCRIPTION
BEGINRELEASENOTES
- Overlay settings moved to Config directory
- Created new constants, energy dependant, for beam size parameters
- High level reco: vertexing
   - Get beam size parameters depending on the CMS energy
   - Use beamspot smearing only if a CMS energy is specified with `--constant.CMSEnergy=...`
- TravisCI test
   - Run simulation for ILD_l/s5_v02 and reconstruction for ILD_l/s5_o1/o2_v02
   - Switch off BeamCalReco to avoid TravisCI timeout and test failure
- Fixed wrong HCal sim calo hit collection names in Calibration file for ILD_s5_o2_v02 model

ENDRELEASENOTES