### PR TITLE
Calibration details in PfoAnalysis processor

### DIFF
--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -284,7 +284,7 @@
     <parameter name="LCalCollections" type="StringVec" lcioInType="CalorimeterHit">LCAL</parameter>
 
     <!--Whether to collect calibration details-->
-    <parameter name="CollectCalibrationDetails" type="int"> 1 </parameter>
+    <parameter name="CollectCalibrationDetails" type="int"> 0 </parameter>
     <!--Name of the ECal collection post ddsim, pre digitisation-->
     <parameter name="ECalCollectionsSimCaloHit" type="StringVec" lcioInType="SimCalorimeterHit">${ECalSimHitCollections}</parameter>
     <!--Name of the HCal Barrel collection post ddsim, pre digitisation-->


### PR DESCRIPTION
BEGINRELEASENOTES
- PfoAnalysis processor config :
   - Switch off the calibration details, saving time and nasty printouts in log files for production

ENDRELEASENOTES