### PR TITLE
Calibration constants for v03, v04, v05, v06 models

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v03.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v03.xml
@@ -1,0 +1,1 @@
+Calibration_ILD_l5_o1_v02.xml

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v04.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v04.xml
@@ -1,0 +1,1 @@
+Calibration_ILD_l5_o1_v02.xml

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v05.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v05.xml
@@ -1,0 +1,1 @@
+Calibration_ILD_l5_o1_v02.xml

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v06.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v06.xml
@@ -1,0 +1,1 @@
+Calibration_ILD_l5_o1_v02.xml

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v03.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v03.xml
@@ -1,0 +1,1 @@
+Calibration_ILD_s5_o1_v02.xml

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v04.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v04.xml
@@ -1,0 +1,1 @@
+Calibration_ILD_s5_o1_v02.xml

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v05.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v05.xml
@@ -1,0 +1,1 @@
+Calibration_ILD_s5_o1_v02.xml

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v06.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v06.xml
@@ -1,0 +1,1 @@
+Calibration_ILD_s5_o1_v02.xml


### PR DESCRIPTION

BEGINRELEASENOTES
- Added symbolic link for calibration constants of v03,4,5,6 models pointing on the v02 model ones

ENDRELEASENOTES