### PR TITLE
 Do not apply senDetFilter for TPC.

### DIFF
--- a/StandardConfig/production/ddsim_steer.py
+++ b/StandardConfig/production/ddsim_steer.py
@@ -138,7 +138,7 @@ SIM.filter.filters = {'edep0': {'parameter': {'Cut': 0.0}, 'name': 'EnergyDeposi
 ##  a map between patterns and filter objects, using patterns to attach filters to sensitive detector 
 SIM.filter.mapDetFilter = {}
 
-SIM.filter.mapDetFilter['TPC'] = "edep0"
+SIM.filter.mapDetFilter['TPC'] = None
 
 ##  default filter for tracking sensitive detectors; this is applied if no other filter is used for a tracker
 SIM.filter.tracker = "edep1kev"


### PR DESCRIPTION
BEGINRELEASENOTES
- Do not apply senDetFilter for TPC.
  - because the TPC sensitive driver need every G4Step information to find out when the track cross the boundary. 

ENDRELEASENOTES
fixes https://github.com/iLCSoft/lcgeo/issues/227