### PR TITLE
add missing calo hit cols to MarlinStdRecoViewer.xml

### DIFF
--- a/StandardConfig/production/MarlinStdRecoViewer.xml
+++ b/StandardConfig/production/MarlinStdRecoViewer.xml
@@ -89,18 +89,26 @@
      EcalEndcapRingPreShower     0 3 2  
      EcalEndcapSiliconCollection 0 3 2  
      EcalEndcapSiliconPreShower  0 3 2  
-     EcalBarrelCollection        0 3 2 
-     EcalBarrelFaceReadout       0 3 2 
-     EcalEndcapFaceReadout       0 3 2 
-     EcalEndcapRingCollection    0 3 2 
-     EcalEndcapsCollection       0 3 2
      HcalBarrelRegCollection     0 3 2
      HcalEndCapRingCollection    0 3 2
-     HcalEndcapsCollection       0 3 2 
+     HcalEndCapsCollection       0 3 2
+     HcalEndcapRingCollection    0 3 2
+     HcalEndcapsCollection       0 3 2
+
+     ECalBarrelSiHitsEven          0 3 2
+     ECalBarrelSiHitsOdd           0 3 2
+     ECalEndcapSiHitsEven          0 3 2
+     ECalEndcapSiHitsOdd           0 3 2
+     EcalBarrelCollection          0 3 2
+     EcalEndcapsCollection         0 3 2
+     YokeEndcapsCollection         0 3 2
 
      ECalBarrelCollection 0 3 2
      ECalEndcapCollection 0 3 2
      ECalPlugCollection 0 3 2
+     EcalBarrelCollection 0 3 2
+     EcalEndcapCollection 0 3 2
+     EcalPlugCollection 0 3 2
      HCalBarrelCollection 0 3 2
      HCalEndcapCollection 0 3 2
      HCalRingCollection 0 3 2
@@ -120,6 +128,12 @@
      ECALEndcap   0 2 12
      ECALOther    0 2 12
      HCALBarrel   0 5 12
+     EcalBarrelCollectionRec      0 5 12
+     EcalEndcapRingCollectionRec  0 5 12
+     EcalEndcapsCollectionRec     0 5 12
+     HcalBarrelCollectionRec      0 5 12
+     HcalEndcapRingCollectionRec  0 5 12
+     HcalEndcapsCollectionRec     0 5 12
 
      TruthTracks      0 6 3
      ForwardTracks    0 6 4


### PR DESCRIPTION

BEGINRELEASENOTES
- add missing (Sim)CalorimterHit collections to the event display steering file MarlinStdRecoViewer.xml

ENDRELEASENOTES