### PR TITLE
set physics.decays = False (fixes DD4hep#513)

### DIFF
--- a/StandardConfig/production/ddsim_steer.py
+++ b/StandardConfig/production/ddsim_steer.py
@@ -243,7 +243,8 @@ SIM.part.saveProcesses = ['Decay']
 ################################################################################
 ## Configuration for the PhysicsList 
 ################################################################################
-SIM.physics.decays = True
+# this needs to be set to False if any standard physics list is used:
+SIM.physics.decays = False
 SIM.physics.list = "QGSP_BERT" # "FTFP_BERT"
 
 ##  location of particle.tbl file containing extra particles and their lifetime information


### PR DESCRIPTION

BEGINRELEASENOTES
- bug fix for decay of 'stable' particles (pi+-,mu+-,K+- and K0L)
      - workaround for https://github.com/AIDASoft/DD4hep/issues/513

ENDRELEASENOTES