### PR TITLE
Photon energy corrections

### DIFF
--- a/StandardConfig/production/CaloDigi/SiWEcalDigi.xml
+++ b/StandardConfig/production/CaloDigi/SiWEcalDigi.xml
@@ -45,7 +45,7 @@
     <parameter name="CellIDLayerString"> layer </parameter>
     <parameter name="CellIDModuleString"> module </parameter>
     <parameter name="CellIDStaveString"> stave </parameter>
-    <parameter name="expectedInterModuleDistance"> 7.0 </parameter>
+    <parameter name="applyInterModuleCorrection"> false </parameter>
   </processor>
   <!--### the Ecal endcaps ###-->
   <!-- digitisation -->
@@ -75,7 +75,7 @@
     <parameter name="CellIDLayerString"> layer </parameter>
     <parameter name="CellIDModuleString"> module </parameter>
     <parameter name="CellIDStaveString"> stave </parameter>
-    <parameter name="expectedInterModuleDistance"> 7.0 </parameter>
+    <parameter name="applyInterModuleCorrection"> false </parameter>
   </processor>
   <!--### the Ecal endcap rings ###-->
   <!-- digitisation -->

--- a/StandardConfig/production/CaloDigi/SiWEcalDigi.xml
+++ b/StandardConfig/production/CaloDigi/SiWEcalDigi.xml
@@ -46,6 +46,7 @@
     <parameter name="CellIDModuleString"> module </parameter>
     <parameter name="CellIDStaveString"> stave </parameter>
     <parameter name="applyInterModuleCorrection"> false </parameter>
+    <parameter name="expectedInterModuleDistance"> 7.0 </parameter>
   </processor>
   <!--### the Ecal endcaps ###-->
   <!-- digitisation -->
@@ -76,6 +77,7 @@
     <parameter name="CellIDModuleString"> module </parameter>
     <parameter name="CellIDStaveString"> stave </parameter>
     <parameter name="applyInterModuleCorrection"> false </parameter>
+    <parameter name="expectedInterModuleDistance"> 7.0 </parameter>
   </processor>
   <!--### the Ecal endcap rings ###-->
   <!-- digitisation -->

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -37,69 +37,68 @@
     <parameter name="MoliereRadius_Hcal" type="float">17.19 </parameter>
   </processor>
 
-  <processor name="MyPhotonCorrectionProcessor" type="photonCorrectionProcessor">
+  <processor name="MyphotonCorrectionProcessor" type="photonCorrectionProcessor">
     <!--photonCorrectionProcessor applies an energy correction to photon-like PFOs-->
-    <parameter name="inputCollection" type="string"> PandoraPFOs </parameter>
-    <parameter name="modifyPFOenergies"> true </parameter>
-    <parameter name="useCorrectorDefaultSet"> 1 </parameter>
-
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
     <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
-    <!--extra correction factor for endcap-->
-    <!-- parameter name="costhCorr_endcap_scale" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus1: mean-->
-    <!-- parameter name="costhCorr_gaus1_mean" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus1: norm (constant)-->
-    <!-- parameter name="costhCorr_gaus1_norm_const" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus1: norm (log(e) coeff)-->
-    <!-- parameter name="costhCorr_gaus1_norm_logen" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus1: sigma-->
-    <!-- parameter name="costhCorr_gaus1_sigm" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus2: mean-->
-    <!-- parameter name="costhCorr_gaus2_mean" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus2: norm (constant)-->
-    <!-- parameter name="costhCorr_gaus2_norm_const" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus2: norm (log(e) coeff)-->
-    <!-- parameter name="costhCorr_gaus2_norm_logen" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus2: sigm-->
-    <!-- parameter name="costhCorr_gaus2_sigm" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus3: mean-->
-    <!-- parameter name="costhCorr_gaus3_mean" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus3: norm (constant)-->
-    <!-- parameter name="costhCorr_gaus3_norm" type="float">-999 </parameter -->
-    <!--barrel cos(theta) correction: gaus3: sigm-->
-    <!-- parameter name="costhCorr_gaus3_sigm" type="float">-999 </parameter -->
-    <!--across endcap module correction: gaus1 mean-->
-    <!-- parameter name="endcap_gaus1_mean" type="float">-999 </parameter -->
-    <!--across endcap module correction: gaus1 norm-->
-    <!-- parameter name="endcap_gaus1_norm" type="float">-999 </parameter -->
-    <!--across endcap module correction: gaus1 sigma-->
-    <!-- parameter name="endcap_gaus1_sigm" type="float">-999 </parameter -->
-    <!--across endcap module correction: gaus2 mean-->
-    <!-- parameter name="endcap_gaus2_mean" type="float">-999 </parameter -->
-    <!--across endcap module correction: gaus2 norm-->
-    <!-- parameter name="endcap_gaus2_norm" type="float">-999 </parameter -->
-    <!--across endcap module correction: gaus2 sigma-->
-    <!-- parameter name="endcap_gaus2_sigm" type="float">-999 </parameter -->
-    <!--overall energy correction: constant term-->
-    <!-- parameter name="energyLin_const" type="float">-999 </parameter -->
-    <!--overall energy correction: log(e) coefficient-->
-    <!-- parameter name="energyLin_logen" type="float">-999 </parameter -->
+    <!--name of input PFO collection-->
+    <parameter name="inputCollection" type="string">PandoraPFOs </parameter>
+    <!--apply the corrected energies to the PFOs-->
+    <parameter name="modifyPFOenergies" type="bool">true </parameter>
     <!--nominal photon energy (for validation plots)-->
-    <!-- parameter name="nominalEnergy" type="float">200 </parameter -->
-    <!--barrel phi correction: gaussian depth-->
-    <!-- parameter name="phiBarrelCorr_depth" type="float">-999 </parameter -->
-    <!--barrel phi correction: central position (constant)-->
-    <!-- parameter name="phiBarrelCorr_pos_const" type="float">-999 </parameter -->
-    <!--barrel phi correction: central position (log(e) coeff)-->
-    <!-- parameter name="phiBarrelCorr_pos_logen" type="float">-999 </parameter -->
-    <!--barrel phi correction: gaussian width (left side)-->
-    <!-- parameter name="phiBarrelCorr_width1" type="float">-999 </parameter -->
-    <!--barrel phi correction: gaussian width (right side)-->
-    <!-- parameter name="phiBarrelCorr_width2" type="float">-999 </parameter -->
+    <parameter name="nominalEnergy" type="float">200 </parameter>
     <!--produce validation plots-->
-    <!-- parameter name="validationPlots" type="bool">false </parameter -->
-
+    <parameter name="validationPlots" type="bool">false </parameter>
+    <!--extra correction factor for endcap-->
+    <parameter name="costhCorr_endcap_scale" type="float">1.002 </parameter>
+    <!--barrel cos(theta) correction: gaus1: mean-->
+    <parameter name="costhCorr_gaus1_mean" type="float">0.235 </parameter>
+    <!--barrel cos(theta) correction: gaus1: norm (constant)-->
+    <parameter name="costhCorr_gaus1_norm_const" type="float">-0.09 </parameter>
+    <!--barrel cos(theta) correction: gaus1: norm (log(e) coeff)-->
+    <parameter name="costhCorr_gaus1_norm_logen" type="float">0 </parameter>
+    <!--barrel cos(theta) correction: gaus1: sigma-->
+    <parameter name="costhCorr_gaus1_sigm" type="float">0.007256 </parameter>
+    <!--barrel cos(theta) correction: gaus2: mean-->
+    <parameter name="costhCorr_gaus2_mean" type="float">0.588 </parameter>
+    <!--barrel cos(theta) correction: gaus2: norm (constant)-->
+    <parameter name="costhCorr_gaus2_norm_const" type="float">-0.0369648 </parameter>
+    <!--barrel cos(theta) correction: gaus2: norm (log(e) coeff)-->
+    <parameter name="costhCorr_gaus2_norm_logen" type="float">0 </parameter>
+    <!--barrel cos(theta) correction: gaus2: sigm-->
+    <parameter name="costhCorr_gaus2_sigm" type="float">0.0121604 </parameter>
+    <!--barrel cos(theta) correction: gaus3: mean-->
+    <parameter name="costhCorr_gaus3_mean" type="float">0.774 </parameter>
+    <!--barrel cos(theta) correction: gaus3: norm (constant)-->
+    <parameter name="costhCorr_gaus3_norm" type="float">-0.0422968 </parameter>
+    <!--barrel cos(theta) correction: gaus3: sigm-->
+    <parameter name="costhCorr_gaus3_sigm" type="float">0.009 </parameter>
+    <!--across endcap module correction: gaus1 mean-->
+    <parameter name="endcap_gaus1_mean" type="float">855 </parameter>
+    <!--across endcap module correction: gaus1 norm-->
+    <parameter name="endcap_gaus1_norm" type="float">-0.025 </parameter>
+    <!--across endcap module correction: gaus1 sigma-->
+    <parameter name="endcap_gaus1_sigm" type="float">23 </parameter>
+    <!--across endcap module correction: gaus2 mean-->
+    <parameter name="endcap_gaus2_mean" type="float">1489 </parameter>
+    <!--across endcap module correction: gaus2 norm-->
+    <parameter name="endcap_gaus2_norm" type="float">-0.07 </parameter>
+    <!--across endcap module correction: gaus2 sigma-->
+    <parameter name="endcap_gaus2_sigm" type="float">18 </parameter>
+    <!--overall energy correction: constant term-->
+    <parameter name="energyLin_const" type="float">0.987 </parameter>
+    <!--overall energy correction: log(e) coefficient-->
+    <parameter name="energyLin_logen" type="float">0.01426 </parameter>
+    <!--barrel phi correction: gaussian depth-->
+    <parameter name="phiBarrelCorr_depth" type="float">-0.0933687 </parameter>
+    <!--barrel phi correction: central position (constant)-->
+    <parameter name="phiBarrelCorr_pos_const" type="float">0.412249 </parameter>
+    <!--barrel phi correction: central position (log(e) coeff)-->
+    <parameter name="phiBarrelCorr_pos_logen" type="float">0.0142289 </parameter>
+    <!--barrel phi correction: gaussian width (left side)-->
+    <parameter name="phiBarrelCorr_width1" type="float">0.01345 </parameter>
+    <!--barrel phi correction: gaussian width (right side)-->
+    <parameter name="phiBarrelCorr_width2" type="float">0.0408156 </parameter>
   </processor>
 
   <processor name="MyPi0Finder" type="GammaGammaCandidateFinder">

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -38,9 +38,68 @@
   </processor>
 
   <processor name="MyPhotonCorrectionProcessor" type="photonCorrectionProcessor">
+    <!--photonCorrectionProcessor applies an energy correction to photon-like PFOs-->
     <parameter name="inputCollection" type="string"> PandoraPFOs </parameter>
     <parameter name="modifyPFOenergies"> true </parameter>
     <parameter name="useCorrectorDefaultSet"> 1 </parameter>
+
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    <!--extra correction factor for endcap-->
+    <!-- parameter name="costhCorr_endcap_scale" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus1: mean-->
+    <!-- parameter name="costhCorr_gaus1_mean" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus1: norm (constant)-->
+    <!-- parameter name="costhCorr_gaus1_norm_const" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus1: norm (log(e) coeff)-->
+    <!-- parameter name="costhCorr_gaus1_norm_logen" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus1: sigma-->
+    <!-- parameter name="costhCorr_gaus1_sigm" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus2: mean-->
+    <!-- parameter name="costhCorr_gaus2_mean" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus2: norm (constant)-->
+    <!-- parameter name="costhCorr_gaus2_norm_const" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus2: norm (log(e) coeff)-->
+    <!-- parameter name="costhCorr_gaus2_norm_logen" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus2: sigm-->
+    <!-- parameter name="costhCorr_gaus2_sigm" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus3: mean-->
+    <!-- parameter name="costhCorr_gaus3_mean" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus3: norm (constant)-->
+    <!-- parameter name="costhCorr_gaus3_norm" type="float">-999 </parameter -->
+    <!--barrel cos(theta) correction: gaus3: sigm-->
+    <!-- parameter name="costhCorr_gaus3_sigm" type="float">-999 </parameter -->
+    <!--across endcap module correction: gaus1 mean-->
+    <!-- parameter name="endcap_gaus1_mean" type="float">-999 </parameter -->
+    <!--across endcap module correction: gaus1 norm-->
+    <!-- parameter name="endcap_gaus1_norm" type="float">-999 </parameter -->
+    <!--across endcap module correction: gaus1 sigma-->
+    <!-- parameter name="endcap_gaus1_sigm" type="float">-999 </parameter -->
+    <!--across endcap module correction: gaus2 mean-->
+    <!-- parameter name="endcap_gaus2_mean" type="float">-999 </parameter -->
+    <!--across endcap module correction: gaus2 norm-->
+    <!-- parameter name="endcap_gaus2_norm" type="float">-999 </parameter -->
+    <!--across endcap module correction: gaus2 sigma-->
+    <!-- parameter name="endcap_gaus2_sigm" type="float">-999 </parameter -->
+    <!--overall energy correction: constant term-->
+    <!-- parameter name="energyLin_const" type="float">-999 </parameter -->
+    <!--overall energy correction: log(e) coefficient-->
+    <!-- parameter name="energyLin_logen" type="float">-999 </parameter -->
+    <!--nominal photon energy (for validation plots)-->
+    <!-- parameter name="nominalEnergy" type="float">200 </parameter -->
+    <!--barrel phi correction: gaussian depth-->
+    <!-- parameter name="phiBarrelCorr_depth" type="float">-999 </parameter -->
+    <!--barrel phi correction: central position (constant)-->
+    <!-- parameter name="phiBarrelCorr_pos_const" type="float">-999 </parameter -->
+    <!--barrel phi correction: central position (log(e) coeff)-->
+    <!-- parameter name="phiBarrelCorr_pos_logen" type="float">-999 </parameter -->
+    <!--barrel phi correction: gaussian width (left side)-->
+    <!-- parameter name="phiBarrelCorr_width1" type="float">-999 </parameter -->
+    <!--barrel phi correction: gaussian width (right side)-->
+    <!-- parameter name="phiBarrelCorr_width2" type="float">-999 </parameter -->
+    <!--produce validation plots-->
+    <!-- parameter name="validationPlots" type="bool">false </parameter -->
+
   </processor>
 
   <processor name="MyPi0Finder" type="GammaGammaCandidateFinder">

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -37,6 +37,11 @@
     <parameter name="MoliereRadius_Hcal" type="float">17.19 </parameter>
   </processor>
 
+  <processor name="MyPhotonCorrectionProcessor" type="photonCorrectionProcessor">
+    <parameter name="inputCollection" type="string"> PandoraPFOs </parameter>
+    <parameter name="modifyPFOenergies"> true </parameter>
+    <parameter name="useCorrectorDefaultSet"> 1 </parameter>
+  </processor>
 
   <processor name="MyPi0Finder" type="GammaGammaCandidateFinder">
     <parameter name="InputParticleCollectionName" value="PandoraPFOs" />


### PR DESCRIPTION
BEGINRELEASENOTES
- turn off gaps between ECAL modules in the BruteForceEcalGapFiller
- run the photonCorrectionProcessor to correct energy of photon PFOs after Pandora
ENDRELEASENOTES

this new config should be used only for ILD_l5_o1_v02 models (and others with the same ECAL structure)