### PR TITLE
Muon digi update

### DIFF
--- a/StandardConfig/production/CaloDigi/MuonDigi.xml
+++ b/StandardConfig/production/CaloDigi/MuonDigi.xml
@@ -18,7 +18,7 @@
     <!--MUON Collection of real Hits-->
     <parameter name="MUONOutputCollection" type="string">MUON </parameter>
     <!--Threshold for MUON Hits in GeV-->
-    <parameter name="MUONThreshold" type="float">1e-06 </parameter>
+    <parameter name="MuonThreshold" type="float">1e-06 </parameter>
     <!--The muon detector name for barrel region-->
     <parameter name="DetectorNameBarrel" type="string"> YokeBarrel </parameter>
     <!--The muon detector name for endcap region-->

--- a/StandardConfig/production/CaloDigi/MuonDigi.xml
+++ b/StandardConfig/production/CaloDigi/MuonDigi.xml
@@ -18,9 +18,9 @@
     <!--MUON Collection of real Hits-->
     <parameter name="MUONOutputCollection" type="string">MUON </parameter>
     <!--Threshold for MUON Hits in GeV-->
-    <parameter name="MuonThreshold" type="float">1e-06 </parameter>
+    <parameter name="MuonThreshold" type="float">1e-03 </parameter>
     <!-- Energy threshold for timing information for Muon Hits in GeV -->
-    <parameter name="MuonTimeThreshold" type="float">1e-06 </parameter>
+    <parameter name="MuonTimeThreshold" type="float">1e-03 </parameter>
     <!--The muon detector name for barrel region-->
     <parameter name="DetectorNameBarrel" type="string"> YokeBarrel </parameter>
     <!--The muon detector name for endcap region-->

--- a/StandardConfig/production/CaloDigi/MuonDigi.xml
+++ b/StandardConfig/production/CaloDigi/MuonDigi.xml
@@ -18,9 +18,9 @@
     <!--MUON Collection of real Hits-->
     <parameter name="MUONOutputCollection" type="string">MUON </parameter>
     <!--Threshold for MUON Hits in GeV-->
-    <parameter name="MuonThreshold" type="float">1e-03 </parameter>
+    <parameter name="MuonThreshold" type="float">0.025 </parameter>
     <!-- Energy threshold for timing information for Muon Hits in GeV -->
-    <parameter name="MuonTimeThreshold" type="float">1e-03 </parameter>
+    <parameter name="MuonTimeThreshold" type="float">0.025 </parameter>
     <!--The muon detector name for barrel region-->
     <parameter name="DetectorNameBarrel" type="string"> YokeBarrel </parameter>
     <!--The muon detector name for endcap region-->

--- a/StandardConfig/production/CaloDigi/MuonDigi.xml
+++ b/StandardConfig/production/CaloDigi/MuonDigi.xml
@@ -19,6 +19,8 @@
     <parameter name="MUONOutputCollection" type="string">MUON </parameter>
     <!--Threshold for MUON Hits in GeV-->
     <parameter name="MuonThreshold" type="float">1e-06 </parameter>
+    <!-- Energy threshold for timing information for Muon Hits in GeV -->
+    <parameter name="MuonTimeThreshold" type="float">1e-06 </parameter>
     <!--The muon detector name for barrel region-->
     <parameter name="DetectorNameBarrel" type="string"> YokeBarrel </parameter>
     <!--The muon detector name for endcap region-->


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed wrong parameter name MUONThreshold -> MuonThreshold
- Set parameter MuonTimeThreshold to the same value as MuonThreshold
- Set threshold value to 0.025 for consistency with 500 GeV MC production

ENDRELEASENOTES

TODO:
- [x] Check the threshold value itself