### PR TITLE
Track refit processors

### DIFF
--- a/StandardConfig/production/Documentation/DSTContent.md
+++ b/StandardConfig/production/Documentation/DSTContent.md
@@ -33,4 +33,6 @@ MC infos :
 
 Tracking :
 - MarlinTrkTracks (Track)
+- MarlinTrkTracksKaon (Track)
+- MarlinTrkTracksProton (Track)
 

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -238,6 +238,8 @@
     <parameter name="KeepCollectionNames" type="StringVec"> 
       MCParticle
       MarlinTrkTracks
+      MarlinTrkTracksProton
+      MarlinTrkTracksKaon
       MCTruthMarlinTrkTracksLink
       MarlinTrkTracksMCTruthLink
       RecoMCTruthLink

--- a/StandardConfig/production/Tracking/TrackingReco.xml
+++ b/StandardConfig/production/Tracking/TrackingReco.xml
@@ -464,5 +464,85 @@
     <parameter name="TrackCollection" type="string"> MarlinTrkTracks</parameter>
   </processor>
   
+  <processor name="MyRefitProcessorKaon" type="RefitProcessor">
+    <!--RefitProcessor refits an input track collection, producing a new collection of tracks. Kaon mass hypothesis-->
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool">true</parameter>
+    <!--Fit direction: -1: backward [default], +1: forward-->
+    <parameter name="FitDirection" type="int">-1</parameter>
+    <!--Value used for the initial d0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorD0" type="float">1e+06</parameter>
+    <!--Value used for the initial omega variance of the trackfit-->
+    <parameter name="InitialTrackErrorOmega" type="float">0.00001</parameter>
+    <!--Value used for the initial phi0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorPhi0" type="float">100</parameter>
+    <!--Value used for the initial tanL variance of the trackfit-->
+    <parameter name="InitialTrackErrorTanL" type="float">100</parameter>
+    <!--Value used for the initial z0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorZ0" type="float">1e+06</parameter>
+    <!--TrackState to use for initialization of the fit: -1: refit from hits [default], 1: AtIP, 2: AtFirstHit, 3: AtLastHit, 4:AtCalo-->
+    <parameter name="InitialTrackState" type="int">3</parameter>
+    <!--Name of the input track collection-->
+    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track">MarlinTrkTracks</parameter>
+    <!--Name of the MCParticle-Track Relations collection for input tracks-->
+    <parameter name="InputTrackRelCollection" type="string" lcioInType="LCRelation" />
+    <!--Maximum Chi-squared value allowed when assigning a hit to a track-->
+    <!--  <parameter name="MaxChi2PerHit" type="float">100 </parameter>-->
+    <!--Use MultipleScattering in Fit-->
+    <!--  <parameter name="MultipleScatteringOn" type="bool">true </parameter>-->
+    <!--Name of the output track collection-->
+    <parameter name="OutputTrackCollectionName" type="string" lcioOutType="Track">MarlinTrkTracksKaon</parameter>
+    <!--Name of the MCParticle-Track Relations collection for output tracks-->
+    <parameter name="OutputTrackRelCollection" type="string" lcioOutType="LCRelation">MarlinTrkTracksKaonMCP</parameter>
+    <!--particle mass that is used in the fit - default is the pion mass: 0.13957018 )-->
+    <parameter name="ParticleMass" type="double">0.493677</parameter>
+    <!--Smooth All Mesurement Sites in Fit-->
+    <!--  <parameter name="SmoothOn" type="bool">false </parameter>-->
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest</parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">MESSAGE</parameter> -->
+  </processor>
+  
+  <processor name="MyRefitProcessorProton" type="RefitProcessor">
+    <!--RefitProcessor refits an input track collection, producing a new collection of tracks. Proton mass hypothesis-->
+    <!--Use Energy Loss in Fit-->
+    <parameter name="EnergyLossOn" type="bool">true</parameter>
+    <!--Fit direction: -1: backward [default], +1: forward-->
+    <parameter name="FitDirection" type="int">-1</parameter>
+    <!--Value used for the initial d0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorD0" type="float">1e+06</parameter>
+    <!--Value used for the initial omega variance of the trackfit-->
+    <parameter name="InitialTrackErrorOmega" type="float">0.00001</parameter>
+    <!--Value used for the initial phi0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorPhi0" type="float">100</parameter>
+    <!--Value used for the initial tanL variance of the trackfit-->
+    <parameter name="InitialTrackErrorTanL" type="float">100</parameter>
+    <!--Value used for the initial z0 variance of the trackfit-->
+    <parameter name="InitialTrackErrorZ0" type="float">1e+06</parameter>
+    <!--TrackState to use for initialization of the fit: -1: refit from hits [default], 1: AtIP, 2: AtFirstHit, 3: AtLastHit, 4:AtCalo-->
+    <parameter name="InitialTrackState" type="int">3</parameter>
+    <!--Name of the input track collection-->
+    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track">MarlinTrkTracks</parameter>
+    <!--Name of the MCParticle-Track Relations collection for input tracks-->
+    <parameter name="InputTrackRelCollection" type="string" lcioInType="LCRelation" />
+    <!--Maximum Chi-squared value allowed when assigning a hit to a track-->
+    <!--  <parameter name="MaxChi2PerHit" type="float">100 </parameter>-->
+    <!--Use MultipleScattering in Fit-->
+    <!--  <parameter name="MultipleScatteringOn" type="bool">true </parameter>-->
+    <!--Name of the output track collection-->
+    <parameter name="OutputTrackCollectionName" type="string" lcioOutType="Track">MarlinTrkTracksProton</parameter>
+    <!--Name of the MCParticle-Track Relations collection for output tracks-->
+    <parameter name="OutputTrackRelCollection" type="string" lcioOutType="LCRelation">MarlinTrkTracksProtonMCP</parameter>
+    <!--particle mass that is used in the fit - default is the pion mass: 0.13957018 )-->
+    <parameter name="ParticleMass" type="double">0.93828</parameter>
+    <!--Smooth All Mesurement Sites in Fit-->
+    <!--  <parameter name="SmoothOn" type="bool">false </parameter>-->
+    <!--Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )-->
+    <parameter name="TrackSystemName" type="string">DDKalTest</parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">MESSAGE</parameter> -->
+  </processor>
+  
 </group>
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Added two processors for track-refitting:
   - `MyRefitProcessorKaon`: refit `MarlinTrkTracks` tracks with a kaon mass hypothesis
   - `MyRefitProcessorProton`: refit `MarlinTrkTracks` tracks with a proton mass hypothesis
- Updated DST content documentation
- DSTOutputProcessor:
   - Keep the `MyRefitProcessorKaon` and `MyRefitProcessorProton` new track collections but drop the relation collections created by the corresponding processors

ENDRELEASENOTES