### PR TITLE
Calibration update (v02-01)

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
@@ -1,28 +1,28 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001525</constant>
-<constant name="EcalEndcapMip">0.0001525</constant>
-<constant name="EcalRingMip">0.0001525</constant>
+<constant name="EcalBarrelMip">0.0001575</constant>
+<constant name="EcalEndcapMip">0.0001575</constant>
+<constant name="EcalRingMip">0.0001575</constant>
 <constant name="HcalBarrelMip">0.0004925</constant>
-<constant name="HcalEndcapMip">0.0004775</constant>
+<constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
-<constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
-<constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
-<constant name="HcalBarrelEnergyFactors">0.0216747245411</constant>
-<constant name="HcalEndcapEnergyFactors">0.0217395864899</constant>
-<constant name="HcalRingEnergyFactors">0.0271318181372</constant>
+<constant name="EcalBarrelEnergyFactors">0.00638915356629 0.0129779714224</constant>
+<constant name="EcalEndcapEnergyFactors">0.00668706922431 0.013583112754</constant>
+<constant name="EcalRingEnergyFactors">0.00668706922431 0.013583112754</constant>
+<constant name="HcalBarrelEnergyFactors">0.0287783798145</constant>
+<constant name="HcalEndcapEnergyFactors">0.0285819096797</constant>
+<constant name="HcalRingEnergyFactors">0.0349940637704</constant>
 <constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">153.846</constant>
-<constant name="PandoraHcalToMip">43.29</constant>
-<constant name="PandoraMuonToMip">10.3093</constant>
+<constant name="PandoraHcalToMip">37.1747</constant>
+<constant name="PandoraMuonToMip">10.5263</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.17344504717</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.17344504717</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
-<constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.59121 -0.0281982 0.000250616 -0.0424222 0.000335128 -2.06112e-05 0.148549 0.199618 -0.0697277</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -1,28 +1,28 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001525</constant>
-<constant name="EcalEndcapMip">0.0001525</constant>
-<constant name="EcalRingMip">0.0001525</constant>
+<constant name="EcalBarrelMip">0.0001575</constant>
+<constant name="EcalEndcapMip">0.0001575</constant>
+<constant name="EcalRingMip">0.0001575</constant>
 <constant name="HcalBarrelMip">0.0004925</constant>
-<constant name="HcalEndcapMip">0.0004775</constant>
+<constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
-<constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
-<constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
-<constant name="HcalBarrelEnergyFactors">0.0216747245411</constant>
-<constant name="HcalEndcapEnergyFactors">0.0217395864899</constant>
-<constant name="HcalRingEnergyFactors">0.0271318181372</constant>
+<constant name="EcalBarrelEnergyFactors">0.00638915356629 0.0129779714224</constant>
+<constant name="EcalEndcapEnergyFactors">0.00668706922431 0.013583112754</constant>
+<constant name="EcalRingEnergyFactors">0.00668706922431 0.013583112754</constant>
+<constant name="HcalBarrelEnergyFactors">0.0287783798145</constant>
+<constant name="HcalEndcapEnergyFactors">0.0285819096797</constant>
+<constant name="HcalRingEnergyFactors">0.0349940637704</constant>
 <constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">153.846</constant>
-<constant name="PandoraHcalToMip">43.29</constant>
-<constant name="PandoraMuonToMip">10.3093</constant>
+<constant name="PandoraHcalToMip">37.1747</constant>
+<constant name="PandoraMuonToMip">10.5263</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.07522318318</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.07522318318</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.17344504717</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.17344504717</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
-<constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.59121 -0.0281982 0.000250616 -0.0424222 0.000335128 -2.06112e-05 0.148549 0.199618 -0.0697277</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
@@ -1,28 +1,28 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001525</constant>
-<constant name="EcalEndcapMip">0.0001525</constant>
-<constant name="EcalRingMip">0.0001525</constant>
-<constant name="HcalBarrelMip">0.0004975</constant>
-<constant name="HcalEndcapMip">0.0004775</constant>
+<constant name="EcalBarrelMip">0.0001575</constant>
+<constant name="EcalEndcapMip">0.0001575</constant>
+<constant name="EcalRingMip">0.0001575</constant>
+<constant name="HcalBarrelMip">0.0004875</constant>
+<constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
-<constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
-<constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
-<constant name="HcalBarrelEnergyFactors">0.0222191436885</constant>
-<constant name="HcalEndcapEnergyFactors">0.0217589517814</constant>
-<constant name="HcalRingEnergyFactors">0.0256860106028</constant>
+<constant name="EcalBarrelEnergyFactors">0.00634087675557 0.0128799091262</constant>
+<constant name="EcalEndcapEnergyFactors">0.00673284555339 0.0136760959457</constant>
+<constant name="EcalRingEnergyFactors">0.00673284555339 0.0136760959457</constant>
+<constant name="HcalBarrelEnergyFactors">0.0286349466631</constant>
+<constant name="HcalEndcapEnergyFactors">0.0286749099338</constant>
+<constant name="HcalRingEnergyFactors">0.0332139689468</constant>
 <constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">153.846</constant>
-<constant name="PandoraHcalToMip">42.1941</constant>
-<constant name="PandoraMuonToMip">10.3093</constant>
+<constant name="PandoraHcalToMip">30.7692</constant>
+<constant name="PandoraMuonToMip">10.5263</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.16859530376</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.16859530376</constant>
 <constant name="PandoraHcalToHadScale">1.0518169704</constant>
-<constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.66382 -0.0455803 0.00091388 -0.00132359 -0.00341433 -5.36844e-05 0.052905 0.0732245 -0.179232</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -1,28 +1,28 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001525</constant>
-<constant name="EcalEndcapMip">0.0001525</constant>
-<constant name="EcalRingMip">0.0001525</constant>
-<constant name="HcalBarrelMip">0.0004975</constant>
-<constant name="HcalEndcapMip">0.0004775</constant>
+<constant name="EcalBarrelMip">0.0001575</constant>
+<constant name="EcalEndcapMip">0.0001575</constant>
+<constant name="EcalRingMip">0.0001575</constant>
+<constant name="HcalBarrelMip">0.0004875</constant>
+<constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.0061295924012 0.0124507376742</constant>
-<constant name="EcalEndcapEnergyFactors">0.00649356022242 0.0131900474958</constant>
-<constant name="EcalRingEnergyFactors">0.00649356022242 0.0131900474958</constant>
-<constant name="HcalBarrelEnergyFactors">0.0222191436885</constant>
-<constant name="HcalEndcapEnergyFactors">0.0217589517814</constant>
-<constant name="HcalRingEnergyFactors">0.0256860106028</constant>
+<constant name="EcalBarrelEnergyFactors">0.00634087675557 0.0128799091262</constant>
+<constant name="EcalEndcapEnergyFactors">0.00673284555339 0.0136760959457</constant>
+<constant name="EcalRingEnergyFactors">0.00673284555339 0.0136760959457</constant>
+<constant name="HcalBarrelEnergyFactors">0.0286349466631</constant>
+<constant name="HcalEndcapEnergyFactors">0.0286749099338</constant>
+<constant name="HcalRingEnergyFactors">0.0332139689468</constant>
 <constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">153.846</constant>
-<constant name="PandoraHcalToMip">42.1941</constant>
-<constant name="PandoraMuonToMip">10.3093</constant>
+<constant name="PandoraHcalToMip">30.7692</constant>
+<constant name="PandoraMuonToMip">10.5263</constant>
 <constant name="PandoraEcalToEMScale">1.0</constant>
 <constant name="PandoraHcalToEMScale">1.0</constant>
-<constant name="PandoraEcalToHadBarrelScale">1.08978523647</constant>
-<constant name="PandoraEcalToHadEndcapScale">1.08978523647</constant>
+<constant name="PandoraEcalToHadBarrelScale">1.16859530376</constant>
+<constant name="PandoraEcalToHadEndcapScale">1.16859530376</constant>
 <constant name="PandoraHcalToHadScale">1.0518169704</constant>
-<constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
+<constant name="PandoraSoftwareCompensationWeights">1.66382 -0.0455803 0.00091388 -0.00132359 -0.00341433 -5.36844e-05 0.052905 0.0732245 -0.179232</constant>
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -257,7 +257,7 @@
     <!--Names of mc particle collection-->
     <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle">MCParticle </parameter>
     <!--Flag to look for quarks with mother Z-->
-    <parameter name="LookForQuarksWithMotherZ" type="int">0 </parameter>
+    <parameter name="LookForQuarksWithMotherZ" type="int">2 </parameter>
     <!--MC pfo selection radius-->
     <parameter name="MCPfoSelectionRadius" type="float">500. </parameter>
     <!--MC pfo selection momentum-->


### PR DESCRIPTION
BEGINRELEASENOTES
- Updated calibration constants for models:
   + `ILD_l5_o1_v02`
   + `ILD_l5_o3_v02`
   + `ILD_s5_o1_v02`
   + `ILD_s5_o3_v02`
- Set `PfoAnalysis.LookForQuarksWithMotherZ` to 2 to deal with new uds generator samples
- **The photon energy correction has not been re-tuned for ILD_s5_v02 variants. To get a proper photon energy correction, you would have to re-run it with the small model**

ENDRELEASENOTES