### PR TITLE
ECal calibration ajustement

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
@@ -9,7 +9,7 @@
 <constant name="HcalRingMip">0.0004875</constant>
 <constant name="EcalBarrelEnergyFactors">0.0063520964756 0.012902699188</constant>
 <constant name="EcalEndcapEnergyFactors">0.0067218419842 0.013653744940</constant>
-<constant name="EcalRingEnergyFactors">0.0067218419842 0.013653744940</constant>
+<constant name="EcalRingEnergyFactors">0.0066536339 0.0135151972</constant>
 <constant name="HcalBarrelEnergyFactors">0.0287783798145</constant>
 <constant name="HcalEndcapEnergyFactors">0.0285819096797</constant>
 <constant name="HcalRingEnergyFactors">0.0349940637704</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
@@ -7,9 +7,9 @@
 <constant name="HcalBarrelMip">0.0004925</constant>
 <constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00638915356629 0.0129779714224</constant>
-<constant name="EcalEndcapEnergyFactors">0.00668706922431 0.013583112754</constant>
-<constant name="EcalRingEnergyFactors">0.00668706922431 0.013583112754</constant>
+<constant name="EcalBarrelEnergyFactors">0.0063520964756 0.012902699188</constant>
+<constant name="EcalEndcapEnergyFactors">0.0067218419842 0.013653744940</constant>
+<constant name="EcalRingEnergyFactors">0.0067218419842 0.013653744940</constant>
 <constant name="HcalBarrelEnergyFactors">0.0287783798145</constant>
 <constant name="HcalEndcapEnergyFactors">0.0285819096797</constant>
 <constant name="HcalRingEnergyFactors">0.0349940637704</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
@@ -5,9 +5,9 @@
 <constant name="EcalEndcapMip">0.0001525</constant>
 <constant name="EcalRingMip">0.0001525</constant>
 <constant name="SDHcalEnergyFactors">0.0367023 0.0745279 0.363042</constant>
-<constant name="EcalBarrelEnergyFactors">0.00616736103247 0.0125274552256</constant>
-<constant name="EcalEndcapEnergyFactors">0.0064868449976 0.0131764071919</constant>
-<constant name="EcalRingEnergyFactors">0.0064868449976 0.0131764071919</constant>
+<constant name="EcalBarrelEnergyFactors">0.0063520964756 0.012902699188</constant>
+<constant name="EcalEndcapEnergyFactors">0.0067218419842 0.013653744940</constant>
+<constant name="EcalRingEnergyFactors">0.0067218419842 0.013653744940</constant>
 <constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">153.846</constant>
 <constant name="PandoraHcalToMip">43.29</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
@@ -7,7 +7,7 @@
 <constant name="SDHcalEnergyFactors">0.0367023 0.0745279 0.363042</constant>
 <constant name="EcalBarrelEnergyFactors">0.0063520964756 0.012902699188</constant>
 <constant name="EcalEndcapEnergyFactors">0.0067218419842 0.013653744940</constant>
-<constant name="EcalRingEnergyFactors">0.0067218419842 0.013653744940</constant>
+<constant name="EcalRingEnergyFactors">0.0066536339 0.0135151972</constant>
 <constant name="MuonCalibration">56.7</constant>
 <constant name="PandoraEcalToMip">153.846</constant>
 <constant name="PandoraHcalToMip">43.29</constant>


### PR DESCRIPTION
BEGINRELEASENOTES
- Adjusted ECal calibration constants for `ILD_l5_o1_v02` and `ILD_l5_o2_v02`:
   - Barrel -0.58% 
   - Endcap +0.52%
   - Ring -0.5%

ENDRELEASENOTES

See https://agenda.linearcollider.org/event/8498/contributions/45417/attachments/35432/54933/photonCheck_v0201.pdf for details