### PR TITLE
dEdX smearing factor update

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
@@ -41,7 +41,7 @@
 <constant name="dEdXErrorFactor">7.55</constant>
 
 <!-- dEdX smearing factor depends on large/small detector flavor -->
-<constant name="dEdXSmearingFactor">0.035</constant>
+<constant name="dEdXSmearingFactor">0.029</constant>
 
 <!-- Particle identification PDF root file for l5(l4) detector -->
 <constant name="PidPDFFile" value="HighLevelReco/PIDFiles/LikelihoodPID_Standard_l5_v01.root" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
@@ -36,7 +36,7 @@
 <constant name="dEdXErrorFactor">7.55</constant>
 
 <!-- dEdX smearing factor depends on large/small detector flavor -->
-<constant name="dEdXSmearingFactor">0.035</constant>
+<constant name="dEdXSmearingFactor">0.029</constant>
 
 <!-- Particle identification PDF root file for l5(l4) detector -->
 <constant name="PidPDFFile" value="HighLevelReco/PIDFiles/LikelihoodPID_Standard_l5_v01.root" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -41,7 +41,7 @@
 <constant name="dEdXErrorFactor">7.55</constant>
 
 <!-- dEdX smearing factor depends on large/small detector flavor -->
-<constant name="dEdXSmearingFactor">0.035</constant>
+<constant name="dEdXSmearingFactor">0.029</constant>
 
 <!-- Particle identification PDF root file for l5(l4) detector -->
 <constant name="PidPDFFile" value="HighLevelReco/PIDFiles/LikelihoodPID_Standard_l5_v01.root" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
@@ -36,7 +36,7 @@
 <constant name="dEdXErrorFactor">7.55</constant>
 
 <!-- dEdX smearing factor depends on large/small detector flavor -->
-<constant name="dEdXSmearingFactor">0.035</constant>
+<constant name="dEdXSmearingFactor">0.029</constant>
 
 <!-- Particle identification PDF root file for l5(l4) detector -->
 <constant name="PidPDFFile" value="HighLevelReco/PIDFiles/LikelihoodPID_Standard_l5_v01.root" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
@@ -41,7 +41,8 @@
 <constant name="dEdXErrorFactor">8.53</constant>
 
 <!-- dEdX smearing factor depends on large/small detector flavor -->
-<constant name="dEdXSmearingFactor">0.044</constant>
+<!-- ATN: This value has been rescaled from the large model value -->
+<constant name="dEdXSmearingFactor">0.036</constant>
 
 <!-- Particle identification PDF root file for s5(s4) detector -->
 <constant name="PidPDFFile" value="HighLevelReco/PIDFiles/LikelihoodPID_Standard_s5_v01.root" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
@@ -36,7 +36,8 @@
 <constant name="dEdXErrorFactor">8.53</constant>
 
 <!-- dEdX smearing factor depends on large/small detector flavor -->
-<constant name="dEdXSmearingFactor">0.044</constant>
+<!-- ATN: This value has been rescaled from the large model value -->
+<constant name="dEdXSmearingFactor">0.036</constant>
 
 <!-- Particle identification PDF root file for s5(s4) detector -->
 <constant name="PidPDFFile" value="HighLevelReco/PIDFiles/LikelihoodPID_Standard_s5_v01.root" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -41,7 +41,8 @@
 <constant name="dEdXErrorFactor">8.53</constant>
 
 <!-- dEdX smearing factor depends on large/small detector flavor -->
-<constant name="dEdXSmearingFactor">0.044</constant>
+<!-- ATN: This value has been rescaled from the large model value -->
+<constant name="dEdXSmearingFactor">0.036</constant>
 
 <!-- Particle identification PDF root file for s5(s4) detector -->
 <constant name="PidPDFFile" value="HighLevelReco/PIDFiles/LikelihoodPID_Standard_s5_v01.root" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
@@ -36,7 +36,8 @@
 <constant name="dEdXErrorFactor">8.53</constant>
 
 <!-- dEdX smearing factor depends on large/small detector flavor -->
-<constant name="dEdXSmearingFactor">0.044</constant>
+<!-- ATN: This value has been rescaled from the large model value -->
+<constant name="dEdXSmearingFactor">0.036</constant>
 
 <!-- Particle identification PDF root file for s5(s4) detector -->
 <constant name="PidPDFFile" value="HighLevelReco/PIDFiles/LikelihoodPID_Standard_s5_v01.root" />


### PR DESCRIPTION
BEGINRELEASENOTES
- Updated dEdX smearing factor:
   - ILD large models: 0.029
   - ILD small models: 0.036 based on large model value

ENDRELEASENOTES