### PR TITLE
Set up the ScECAL reconstruction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - SIM_MODEL=ILD_s5_v02 REC_MODEL=ILD_s5_o1_v02
     - SIM_MODEL=ILD_l5_v02 REC_MODEL=ILD_l5_o2_v02
     - SIM_MODEL=ILD_s5_v02 REC_MODEL=ILD_s5_o2_v02
+    - SIM_MODEL=ILD_l5_v02 REC_MODEL=ILD_l5_o3_v02
 
 services:
   - docker

--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.xml
@@ -23,6 +23,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.07045526314</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.78321 -0.0515853 0.000555338 -0.0858048 0.00546042 -0.000151165 0.0601101 0.069058 -0.113743</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.xml
@@ -18,6 +18,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
 <constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.78321 -0.0515853 0.000555338 -0.0858048 0.00546042 -0.000151165 0.0601101 0.069058 -0.113743</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.xml
@@ -23,6 +23,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.17344504717</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.59121 -0.0281982 0.000250616 -0.0424222 0.000335128 -2.06112e-05 0.148549 0.199618 -0.0697277</constant>
+<constant name="ApplyPhotonPFOCorrections" value="true" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.xml
@@ -18,6 +18,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
 <constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
+<constant name="ApplyPhotonPFOCorrections" value="true" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -23,6 +23,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.17344504717</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.59121 -0.0281982 0.000250616 -0.0424222 0.000335128 -2.06112e-05 0.148549 0.199618 -0.0697277</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -17,8 +17,8 @@
 <constant name="PandoraEcalToMip">153.846</constant>
 <constant name="PandoraHcalToMip">37.1747</constant>
 <constant name="PandoraMuonToMip">10.5263</constant>
-<constant name="PandoraEcalToEMScale">1.032</constant>
-<constant name="PandoraHcalToEMScale">1.030</constant>
+<constant name="PandoraEcalToEMScale">1.031</constant>
+<constant name="PandoraHcalToEMScale">1.0</constant>
 <constant name="PandoraEcalToHadBarrelScale">1.17344504717</constant>
 <constant name="PandoraEcalToHadEndcapScale">1.17344504717</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -17,8 +17,8 @@
 <constant name="PandoraEcalToMip">153.846</constant>
 <constant name="PandoraHcalToMip">37.1747</constant>
 <constant name="PandoraMuonToMip">10.5263</constant>
-<constant name="PandoraEcalToEMScale">1.0</constant>
-<constant name="PandoraHcalToEMScale">1.0</constant>
+<constant name="PandoraEcalToEMScale">1.032</constant>
+<constant name="PandoraHcalToEMScale">1.030</constant>
 <constant name="PandoraEcalToHadBarrelScale">1.17344504717</constant>
 <constant name="PandoraEcalToHadEndcapScale">1.17344504717</constant>
 <constant name="PandoraHcalToHadScale">1.02821419758</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -7,8 +7,8 @@
 <constant name="HcalBarrelMip">0.0004925</constant>
 <constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors"> 0.00763 0.01526 </constant>
-<constant name="EcalEndcapEnergyFactors"> 0.00806 0.01612 </constant>
+<constant name="EcalBarrelEnergyFactors"> 0.00758 0.01515 </constant>
+<constant name="EcalEndcapEnergyFactors"> 0.00810 0.01619 </constant>
 <constant name="EcalRingEnergyFactors">0.00668706922431 0.013583112754</constant>
 <constant name="HcalBarrelEnergyFactors">0.0287783798145</constant>
 <constant name="HcalEndcapEnergyFactors">0.0285819096797</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
+<constant name="EcalBarrelMip">0.0003</constant>
+<constant name="EcalEndcapMip">0.0003</constant>
 <constant name="EcalRingMip">0.0001575</constant>
 <constant name="HcalBarrelMip">0.0004925</constant>
 <constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00638915356629 0.0129779714224</constant>
-<constant name="EcalEndcapEnergyFactors">0.00668706922431 0.013583112754</constant>
+<constant name="EcalBarrelEnergyFactors"> 0.0057 0.0114 </constant>
+<constant name="EcalEndcapEnergyFactors"> 0.0057 0.0114 </constant>
 <constant name="EcalRingEnergyFactors">0.00668706922431 0.013583112754</constant>
 <constant name="HcalBarrelEnergyFactors">0.0287783798145</constant>
 <constant name="HcalEndcapEnergyFactors">0.0285819096797</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0003</constant>
-<constant name="EcalEndcapMip">0.0003</constant>
+<constant name="EcalBarrelMip"> 0.0002629 </constant>
+<constant name="EcalEndcapMip"> 0.0002655 </constant>
 <constant name="EcalRingMip">0.0001575</constant>
 <constant name="HcalBarrelMip">0.0004925</constant>
 <constant name="HcalEndcapMip">0.0004725</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -7,8 +7,8 @@
 <constant name="HcalBarrelMip">0.0004925</constant>
 <constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors"> 0.0057 0.0114 </constant>
-<constant name="EcalEndcapEnergyFactors"> 0.0057 0.0114 </constant>
+<constant name="EcalBarrelEnergyFactors"> 0.00853 0.01706 </constant>
+<constant name="EcalEndcapEnergyFactors"> 0.00853 0.01706 </constant>
 <constant name="EcalRingEnergyFactors">0.00668706922431 0.013583112754</constant>
 <constant name="HcalBarrelEnergyFactors">0.0287783798145</constant>
 <constant name="HcalEndcapEnergyFactors">0.0285819096797</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.xml
@@ -7,8 +7,8 @@
 <constant name="HcalBarrelMip">0.0004925</constant>
 <constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors"> 0.00853 0.01706 </constant>
-<constant name="EcalEndcapEnergyFactors"> 0.00853 0.01706 </constant>
+<constant name="EcalBarrelEnergyFactors"> 0.00763 0.01526 </constant>
+<constant name="EcalEndcapEnergyFactors"> 0.00806 0.01612 </constant>
 <constant name="EcalRingEnergyFactors">0.00668706922431 0.013583112754</constant>
 <constant name="HcalBarrelEnergyFactors">0.0287783798145</constant>
 <constant name="HcalEndcapEnergyFactors">0.0285819096797</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.xml
@@ -18,6 +18,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.20499007655</constant>
 <constant name="PandoraHcalToHadScale">0.992344768925</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.66803 -0.031982 0.000192898 -0.0612971 0.00256256 -4.35641e-05 0.0558589 0.0601767 -0.0758029</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.xml
@@ -23,6 +23,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.20700253651</constant>
 <constant name="PandoraHcalToHadScale">1.04116630643</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.67738 -0.0324571 0.000211756 -0.0652524 0.00258787 -4.47897e-05 0.057609 0.0659326 -0.0757052</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.xml
@@ -18,6 +18,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.31</constant>
 <constant name="PandoraHcalToHadScale">0.98</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.67738 -0.0324571 0.000211756 -0.0652524 0.00258787 -4.47897e-05 0.057609 0.0659326 -0.0757052</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.xml
@@ -23,6 +23,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.16859530376</constant>
 <constant name="PandoraHcalToHadScale">1.0518169704</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.66382 -0.0455803 0.00091388 -0.00132359 -0.00341433 -5.36844e-05 0.052905 0.0732245 -0.179232</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.xml
@@ -18,6 +18,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.31</constant>
 <constant name="PandoraHcalToHadScale">0.98</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="SiWEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -17,8 +17,8 @@
 <constant name="PandoraEcalToMip">153.846</constant>
 <constant name="PandoraHcalToMip">30.7692</constant>
 <constant name="PandoraMuonToMip">10.5263</constant>
-<constant name="PandoraEcalToEMScale">1.0</constant>
-<constant name="PandoraHcalToEMScale">1.0</constant>
+<constant name="PandoraEcalToEMScale">1.032</constant>
+<constant name="PandoraHcalToEMScale">1.030</constant>
 <constant name="PandoraEcalToHadBarrelScale">1.16859530376</constant>
 <constant name="PandoraEcalToHadEndcapScale">1.16859530376</constant>
 <constant name="PandoraHcalToHadScale">1.0518169704</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -17,8 +17,8 @@
 <constant name="PandoraEcalToMip">153.846</constant>
 <constant name="PandoraHcalToMip">30.7692</constant>
 <constant name="PandoraMuonToMip">10.5263</constant>
-<constant name="PandoraEcalToEMScale">1.032</constant>
-<constant name="PandoraHcalToEMScale">1.030</constant>
+<constant name="PandoraEcalToEMScale">1.031</constant>
+<constant name="PandoraHcalToEMScale">1.0</constant>
 <constant name="PandoraEcalToHadBarrelScale">1.16859530376</constant>
 <constant name="PandoraEcalToHadEndcapScale">1.16859530376</constant>
 <constant name="PandoraHcalToHadScale">1.0518169704</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -7,8 +7,8 @@
 <constant name="HcalBarrelMip">0.0004875</constant>
 <constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors"> 0.00763 0.01526 </constant>
-<constant name="EcalEndcapEnergyFactors"> 0.00806 0.01612 </constant>
+<constant name="EcalBarrelEnergyFactors"> 0.00758 0.01515 </constant>
+<constant name="EcalEndcapEnergyFactors"> 0.00810 0.01619 </constant>
 <constant name="EcalRingEnergyFactors">0.00673284555339 0.0136760959457</constant>
 <constant name="HcalBarrelEnergyFactors">0.0286349466631</constant>
 <constant name="HcalEndcapEnergyFactors">0.0286749099338</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='ASCII'?>
 
 <!-- Calibration constants -->
-<constant name="EcalBarrelMip">0.0001575</constant>
-<constant name="EcalEndcapMip">0.0001575</constant>
+<constant name="EcalBarrelMip"> 0.0002629 </constant>
+<constant name="EcalEndcapMip"> 0.0002655 </constant>
 <constant name="EcalRingMip">0.0001575</constant>
 <constant name="HcalBarrelMip">0.0004875</constant>
 <constant name="HcalEndcapMip">0.0004725</constant>
 <constant name="HcalRingMip">0.0004875</constant>
-<constant name="EcalBarrelEnergyFactors">0.00634087675557 0.0128799091262</constant>
-<constant name="EcalEndcapEnergyFactors">0.00673284555339 0.0136760959457</constant>
+<constant name="EcalBarrelEnergyFactors"> 0.00763 0.01526 </constant>
+<constant name="EcalEndcapEnergyFactors"> 0.00806 0.01612 </constant>
 <constant name="EcalRingEnergyFactors">0.00673284555339 0.0136760959457</constant>
 <constant name="HcalBarrelEnergyFactors">0.0286349466631</constant>
 <constant name="HcalEndcapEnergyFactors">0.0286749099338</constant>

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.xml
@@ -23,6 +23,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.16859530376</constant>
 <constant name="PandoraHcalToHadScale">1.0518169704</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.66382 -0.0455803 0.00091388 -0.00132359 -0.00341433 -5.36844e-05 0.052905 0.0732245 -0.179232</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.xml
@@ -18,6 +18,7 @@
 <constant name="PandoraEcalToHadEndcapScale">1.31</constant>
 <constant name="PandoraHcalToHadScale">0.98</constant>
 <constant name="PandoraSoftwareCompensationWeights">1.45525 -0.0243366 0.000133654 -0.0529633 0.00148587 -2.11343e-05 0.136194 0.151678 -0.0514051</constant>
+<constant name="ApplyPhotonPFOCorrections" value="false" />
 
 <!-- Ecal technology : SiWEcal or ScEcal -->
 <constant name="EcalTechnology" value="ScEcal" />

--- a/StandardConfig/production/CaloDigi/ScEcalDigi.xml
+++ b/StandardConfig/production/CaloDigi/ScEcalDigi.xml
@@ -36,6 +36,8 @@
     <parameter name="inputRelationCollections"> ECalBarrelScHitsEvenDigiRelations </parameter>
     <parameter name="outputHitCollections"> ECalBarrelScHitsEvenRec </parameter>
     <parameter name="outputRelationCollections"> ECalBarrelScHitsEvenRecRelations </parameter>
+    <parameter name="ppd_mipPe"> 10 </parameter>
+    <parameter name="ppd_npix"> 10000 </parameter>
     <parameter name="calibration_layergroups"> 20 11 </parameter>
     <parameter name="calibration_factorsMipGev">${EcalBarrelEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
@@ -45,6 +47,8 @@
     <parameter name="inputRelationCollections"> ECalBarrelScHitsOddDigiRelations </parameter>
     <parameter name="outputHitCollections"> ECalBarrelScHitsOddRec </parameter>
     <parameter name="outputRelationCollections"> ECalBarrelScHitsOddRecRelations </parameter>
+    <parameter name="ppd_mipPe"> 10 </parameter>
+    <parameter name="ppd_npix"> 10000 </parameter>
     <parameter name="calibration_layergroups"> 20 11 </parameter>
     <parameter name="calibration_factorsMipGev">${EcalBarrelEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
@@ -86,8 +90,8 @@
     <parameter name="inputRelationCollections"> ECalEndcapScHitsEvenDigiRelations </parameter>
     <parameter name="outputHitCollections"> ECalEndcapScHitsEvenRec </parameter>
     <parameter name="outputRelationCollections"> ECalEndcapScHitsEvenRecRelations </parameter>
-    <parameter name="ppd_mipPe"> 10 </parameter> 
-    <parameter name="ppd_npix"> 10000 </parameter> 
+    <parameter name="ppd_mipPe"> 10 </parameter>
+    <parameter name="ppd_npix"> 10000 </parameter>
     <parameter name="calibration_layergroups"> 20 11 </parameter>
     <parameter name="calibration_factorsMipGev">${EcalEndcapEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
@@ -97,8 +101,8 @@
     <parameter name="inputRelationCollections"> ECalEndcapScHitsOddDigiRelations </parameter>
     <parameter name="outputHitCollections"> ECalEndcapScHitsOddRec </parameter>
     <parameter name="outputRelationCollections"> ECalEndcapScHitsOddRecRelations </parameter>
-    <parameter name="ppd_mipPe"> 10 </parameter> 
-    <parameter name="ppd_npix"> 10000 </parameter> 
+    <parameter name="ppd_mipPe"> 10 </parameter>
+    <parameter name="ppd_npix"> 10000 </parameter>
     <parameter name="calibration_layergroups"> 20 11 </parameter>
     <parameter name="calibration_factorsMipGev">${EcalEndcapEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>

--- a/StandardConfig/production/CaloDigi/ScEcalDigi.xml
+++ b/StandardConfig/production/CaloDigi/ScEcalDigi.xml
@@ -1,76 +1,107 @@
-
-
 <group name="EcalDigi">
-
-  <processor name="MergeCollectionsEcalBarrelHits" type="MergeCollections">
-    <parameter name="InputCollections" type="StringVec"> ECalBarrelSiHitsEven ECalBarrelSiHitsOdd </parameter>
-    <parameter name="OutputCollection" type="string"> EcalBarrelCollection </parameter>
-  </processor>
-
-  <processor name="MergeCollectionsEcalEndcapHits" type="MergeCollections">
-    <parameter name="InputCollections" type="StringVec"> ECalEndcapSiHitsEven ECalEndcapSiHitsOdd </parameter>
-    <parameter name="OutputCollection" type="string"> EcalEndcapsCollection </parameter>
-  </processor>
 
   <!--### the Ecal barrel ###-->
   <!--digitisation -->
-  <processor name="MyEcalBarrelDigi" type="RealisticCaloDigiSilicon">
-    <parameter name="inputHitCollections"> EcalBarrelCollection </parameter>
-    <parameter name="outputHitCollections"> EcalBarrelCollectionDigi </parameter>
-    <parameter name="outputRelationCollections"> EcalBarrelRelationsSimDigi </parameter>
+  <processor name="MyEcalBarrelDigiEven" type="RealisticCaloDigiScinPpd">
+    <parameter name="inputHitCollections"> ECalBarrelScHitsEven </parameter>
+    <parameter name="outputHitCollections"> ECalBarrelScHitsEvenDigi </parameter>
+    <parameter name="outputRelationCollections"> ECalBarrelScHitsEvenDigiRelations </parameter>
     <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="thresholdUnit"> MIP </parameter>
     <parameter name="timingCut"> 1  </parameter>
     <parameter name="calibration_mip">${EcalBarrelMip}</parameter>
+    <parameter name="ppd_mipPe"> 10 </parameter>
+    <parameter name="ppd_npix"> 10000 </parameter>
+    <parameter name="ppd_npix_uncert"> 0 </parameter>
+    <parameter name="ppd_pix_spread"> 0 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <processor name="MyEcalBarrelDigiOdd" type="RealisticCaloDigiScinPpd">
+    <parameter name="inputHitCollections"> ECalBarrelScHitsOdd </parameter>
+    <parameter name="outputHitCollections"> ECalBarrelScHitsOddDigi </parameter>
+    <parameter name="outputRelationCollections"> ECalBarrelScHitsOddDigiRelations </parameter>
+    <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="thresholdUnit"> MIP </parameter>
+    <parameter name="timingCut"> 1  </parameter>
+    <parameter name="calibration_mip">${EcalBarrelMip}</parameter>
+    <parameter name="ppd_mipPe"> 10 </parameter>
+    <parameter name="ppd_npix"> 10000 </parameter>
+    <parameter name="ppd_npix_uncert"> 0 </parameter>
+    <parameter name="ppd_pix_spread"> 0 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
   <!-- reconstruction -->
-  <processor name="MyEcalBarrelReco" type="RealisticCaloRecoSilicon">
-    <parameter name="inputHitCollections"> EcalBarrelCollectionDigi </parameter>
-    <parameter name="inputRelationCollections"> EcalBarrelRelationsSimDigi </parameter>
-    <parameter name="outputHitCollections"> EcalBarrelCollectionRec </parameter>
-    <parameter name="outputRelationCollections"> EcalBarrelRelationsSimRec </parameter>
+  <processor name="MyEcalBarrelRecoEven" type="RealisticCaloRecoScinPpd">
+    <parameter name="inputHitCollections"> ECalBarrelScHitsEvenDigi </parameter>
+    <parameter name="inputRelationCollections"> ECalBarrelScHitsEvenDigiRelations </parameter>
+    <parameter name="outputHitCollections"> ECalBarrelScHitsEvenRec </parameter>
+    <parameter name="outputRelationCollections"> ECalBarrelScHitsEvenRecRelations </parameter>
     <parameter name="calibration_layergroups"> 20 11 </parameter>
     <parameter name="calibration_factorsMipGev">${EcalBarrelEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
-  <!-- gap filling -->
-  <processor name="MyEcalBarrelGapFiller" type="BruteForceEcalGapFiller">
-    <parameter name="inputHitCollection"> EcalBarrelCollectionRec </parameter>
-    <parameter name="outputHitCollection"> EcalBarrelCollectionGapHits </parameter>
+  <processor name="MyEcalBarrelRecoOdd" type="RealisticCaloRecoScinPpd">
+    <parameter name="inputHitCollections"> ECalBarrelScHitsOddDigi </parameter>
+    <parameter name="inputRelationCollections"> ECalBarrelScHitsOddDigiRelations </parameter>
+    <parameter name="outputHitCollections"> ECalBarrelScHitsOddRec </parameter>
+    <parameter name="outputRelationCollections"> ECalBarrelScHitsOddRecRelations </parameter>
+    <parameter name="calibration_layergroups"> 20 11 </parameter>
+    <parameter name="calibration_factorsMipGev">${EcalBarrelEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
-    <parameter name="CellIDModuleString"> module </parameter>
-    <parameter name="CellIDStaveString"> stave </parameter>
-    <parameter name="expectedInterModuleDistance"> 7.0 </parameter>
   </processor>
-  <!--### the Ecal endcaps ###-->
+
+ <!--### the Ecal endcaps ###-->
   <!-- digitisation -->
-  <processor name="MyEcalEndcapDigi" type="RealisticCaloDigiSilicon">
-    <parameter name="inputHitCollections"> EcalEndcapsCollection </parameter>
-    <parameter name="outputHitCollections"> EcalEndcapsCollectionDigi </parameter>
-    <parameter name="outputRelationCollections"> EcalEndcapsRelationsSimDigi </parameter>
+  <processor name="MyEcalEndcapDigiEven" type="RealisticCaloDigiScinPpd">
+    <parameter name="inputHitCollections"> ECalEndcapScHitsEven </parameter>
+    <parameter name="outputHitCollections"> ECalEndcapScHitsEvenDigi </parameter>
+    <parameter name="outputRelationCollections"> ECalEndcapScHitsEvenDigiRelations </parameter>
     <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="thresholdUnit"> MIP </parameter>
     <parameter name="timingCut"> 1  </parameter>
     <parameter name="calibration_mip">${EcalEndcapMip}</parameter>
+    <parameter name="ppd_mipPe"> 10 </parameter>
+    <parameter name="ppd_npix"> 10000 </parameter>
+    <parameter name="ppd_npix_uncert"> 0 </parameter>
+    <parameter name="ppd_pix_spread"> 0 </parameter>
+    <parameter name="CellIDLayerString"> layer </parameter>
+  </processor>
+  <processor name="MyEcalEndcapDigiOdd" type="RealisticCaloDigiScinPpd">
+    <parameter name="inputHitCollections"> ECalEndcapScHitsOdd </parameter>
+    <parameter name="outputHitCollections"> ECalEndcapScHitsOddDigi </parameter>
+    <parameter name="outputRelationCollections"> ECalEndcapScHitsOddDigiRelations </parameter>
+    <parameter name="threshold"> 0.5 </parameter>
+    <parameter name="thresholdUnit"> MIP </parameter>
+    <parameter name="timingCut"> 1  </parameter>
+    <parameter name="calibration_mip">${EcalEndcapMip}</parameter>
+    <parameter name="ppd_mipPe"> 10 </parameter>
+    <parameter name="ppd_npix"> 10000 </parameter>
+    <parameter name="ppd_npix_uncert"> 0 </parameter>
+    <parameter name="ppd_pix_spread"> 0 </parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
   <!-- reconstruction -->
-  <processor name="MyEcalEndcapReco" type="RealisticCaloRecoSilicon">
-    <parameter name="inputHitCollections"> EcalEndcapsCollectionDigi </parameter>
-    <parameter name="inputRelationCollections"> EcalEndcapsRelationsSimDigi </parameter>
-    <parameter name="outputHitCollections"> EcalEndcapsCollectionRec </parameter>
-    <parameter name="outputRelationCollections"> EcalEndcapsRelationsSimRec </parameter>
+  <processor name="MyEcalEndcapRecoEven" type="RealisticCaloRecoScinPpd">
+    <parameter name="inputHitCollections"> ECalEndcapScHitsEvenDigi </parameter>
+    <parameter name="inputRelationCollections"> ECalEndcapScHitsEvenDigiRelations </parameter>
+    <parameter name="outputHitCollections"> ECalEndcapScHitsEvenRec </parameter>
+    <parameter name="outputRelationCollections"> ECalEndcapScHitsEvenRecRelations </parameter>
+    <parameter name="ppd_mipPe"> 10 </parameter> 
+    <parameter name="ppd_npix"> 10000 </parameter> 
     <parameter name="calibration_layergroups"> 20 11 </parameter>
     <parameter name="calibration_factorsMipGev">${EcalEndcapEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
-  <!-- gap filling -->
-  <processor name="MyEcalEndcapGapFiller" type="BruteForceEcalGapFiller">
-    <parameter name="inputHitCollection"> EcalEndcapsCollectionRec </parameter>
-    <parameter name="outputHitCollection"> EcalEndcapsCollectionGapHits </parameter>
+  <processor name="MyEcalEndcapRecoOdd" type="RealisticCaloRecoScinPpd">
+    <parameter name="inputHitCollections"> ECalEndcapScHitsOddDigi </parameter>
+    <parameter name="inputRelationCollections"> ECalEndcapScHitsOddDigiRelations </parameter>
+    <parameter name="outputHitCollections"> ECalEndcapScHitsOddRec </parameter>
+    <parameter name="outputRelationCollections"> ECalEndcapScHitsOddRecRelations </parameter>
+    <parameter name="ppd_mipPe"> 10 </parameter> 
+    <parameter name="ppd_npix"> 10000 </parameter> 
+    <parameter name="calibration_layergroups"> 20 11 </parameter>
+    <parameter name="calibration_factorsMipGev">${EcalEndcapEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
-    <parameter name="CellIDModuleString"> module </parameter>
-    <parameter name="CellIDStaveString"> stave </parameter>
-    <parameter name="expectedInterModuleDistance"> 7.0 </parameter>
   </processor>
   <!--### the Ecal endcap rings ###-->
   <!-- digitisation -->
@@ -83,6 +114,7 @@
     <parameter name="calibration_mip">${EcalRingMip}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
+
   <!-- reconstruction -->
   <processor name="MyEcalRingReco" type="RealisticCaloRecoSilicon">
     <parameter name="inputHitCollections"> EcalEndcapRingCollectionDigi </parameter>
@@ -93,5 +125,90 @@
     <parameter name="calibration_factorsMipGev">${EcalRingEnergyFactors}</parameter>
     <parameter name="CellIDLayerString"> layer </parameter>
   </processor>
+  
+  <!-- strip splitting (barrel) -->
+  <processor name="MyDDStripSplitterBarrel" type="DDStripSplitter">
+    <parameter name="ECALcollection_evenLayers"> ECalBarrelScHitsEvenRec </parameter>
+    <parameter name="ECALcollection_oddLayers">  ECalBarrelScHitsOddRec </parameter>
+    <parameter name="LCRelations_evenLayers"> ECalBarrelScHitsEvenRecRelations </parameter>
+    <parameter name="LCRelations_oddLayers"> ECalBarrelScHitsOddRecRelations </parameter>
+    <parameter name="isBarrelHits"> true </parameter>
+    <parameter name="splitEcalCollection">   ECalBarrelScHitsSplit </parameter>
+    <parameter name="unsplitEcalCollection"> ECalBarrelScHitsUnSplit </parameter>
+    <parameter name="splitEcalRelCol"> EcalBarrelRelationsSimRec </parameter>
+  </processor>
+  
+  <!-- strip splitting (endcap) -->
+  <processor name="MyDDStripSplitterEndcap" type="DDStripSplitter">
+    <parameter name="ECALcollection_oddLayers">  ECalEndcapScHitsOddRec </parameter>
+    <parameter name="ECALcollection_evenLayers"> ECalEndcapScHitsEvenRec </parameter>
+    <parameter name="LCRelations_evenLayers"> ECalEndcapScHitsEvenRecRelations </parameter>
+    <parameter name="LCRelations_oddLayers">  ECalEndcapScHitsOddRecRelations </parameter>
+    <parameter name="isBarrelHits"> false </parameter>
+    <parameter name="splitEcalCollection">   ECalEndcapScHitsSplit </parameter>
+    <parameter name="unsplitEcalCollection"> ECalEndcapScHitsUnSplit </parameter>
+    <parameter name="splitEcalRelCol"> EcalEndcapRelationsSimRec </parameter>
+  </processor>
+  
+  <!-- Merge even and odd collections -->
+  <!-- the simhits -->
+  <processor name="MergeEcalBarrelHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalBarrelScHitsEven ECalBarrelScHitsOdd </parameter>
+    <parameter name="OutputCollection" type="string"> EcalBarrelCollection </parameter>
+  </processor>
+  <processor name="MergeEcalEndcapHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalEndcapScHitsEven ECalEndcapScHitsOdd </parameter>
+    <parameter name="OutputCollection" type="string"> EcalEndcapsCollection </parameter>
+  </processor>
+  <!-- digitised hits -->
+  <processor name="MergeEcalBarrelDigiHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalBarrelScHitsEvenDigi ECalBarrelScHitsOddDigi </parameter>
+    <parameter name="OutputCollection" type="string"> EcalBarrelCollectionDigi </parameter>
+  </processor>
+  <processor name="MergeEcalEndcapDigiHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalEndcapScHitsEvenDigi ECalEndcapScHitsOddDigi </parameter>
+    <parameter name="OutputCollection" type="string"> EcalEndcapsCollectionDigi </parameter>
+  </processor>
+  <!-- reconstructed hits (strips) -->
+  <processor name="MergeEcalBarrelRecStripHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalBarrelScHitsEvenRec ECalBarrelScHitsOddRec </parameter>
+    <parameter name="OutputCollection" type="string"> EcalBarrelStripCollectionRec </parameter>
+  </processor>
+  <processor name="MergeEcalEndcapRecStripHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalEndcapScHitsEvenRec ECalEndcapScHitsOddRec </parameter>
+    <parameter name="OutputCollection" type="string"> EcalEndcapStripCollectionRec </parameter>
+  </processor>
+  <!-- reconstructed hits (after splitting) -->
+  <processor name="MergeEcalBarrelRecHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalBarrelScHitsSplit ECalBarrelScHitsUnSplit </parameter>
+    <parameter name="OutputCollection" type="string"> EcalBarrelCollectionRec </parameter>
+  </processor>
+  <processor name="MergeEcalEndcapRecHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalEndcapScHitsSplit ECalEndcapScHitsUnSplit </parameter>
+    <parameter name="OutputCollection" type="string"> EcalEndcapsCollectionRec </parameter>
+  </processor>
+  <!-- relations: DIGI to SIM -->
+<!--
+  <processor name="MergeEcalBarrelRelDigiHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalBarrelScHitsEvenDigiRelations ECalBarrelScHitsOddDigiRelations </parameter>
+    <parameter name="OutputCollection" type="string"> EcalBarrelRelationsSimDigi </parameter>
+  </processor>
+  <processor name="MergeEcalEndcapRelDigiHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalEndcapScHitsEvenDigiRelations ECalEndcapScHitsOddDigiRelations </parameter>
+    <parameter name="OutputCollection" type="string"> EcalEndcapsRelationsSimDigi </parameter>
+  </processor>
+-->
+  <!-- relations: REC to SIM -->
+<!--
+  <processor name="MergeEcalBarrelRelRecStripHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalBarrelScHitsEvenRecRelations ECalBarrelScHitsOddRecRelations </parameter>
+    <parameter name="OutputCollection" type="string"> EcalBarrelStripRelationsSimRec </parameter>
+  </processor>
+  <processor name="MergeEcalEndcapRelRecStripHits" type="MergeCollections">
+    <parameter name="InputCollections" type="StringVec"> ECalEndcapScHitsEvenDigiRelations ECalEndcapScHitsOddDigiRelations </parameter>
+    <parameter name="OutputCollection" type="string"> EcalEndcapsStripRelationsSimRec </parameter>
+  </processor>
+-->
 
 </group>
+

--- a/StandardConfig/production/CaloDigi/ScEcalDigi.xml
+++ b/StandardConfig/production/CaloDigi/ScEcalDigi.xml
@@ -151,7 +151,7 @@
     <parameter name="isBarrelHits"> false </parameter>
     <parameter name="splitEcalCollection">   ECalEndcapScHitsSplit </parameter>
     <parameter name="unsplitEcalCollection"> ECalEndcapScHitsUnSplit </parameter>
-    <parameter name="splitEcalRelCol"> EcalEndcapRelationsSimRec </parameter>
+    <parameter name="splitEcalRelCol"> EcalEndcapsRelationsSimRec </parameter>
   </processor>
   
   <!-- Merge even and odd collections -->

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -44,9 +44,9 @@
     <!--name of input PFO collection-->
     <parameter name="inputCollection" type="string">PandoraPFOs </parameter>
     <!--apply the corrected energies to the PFOs-->
-    <parameter name="modifyPFOenergies" type="bool">true </parameter>
+    <parameter name="modifyPFOenergies" type="bool"> ${ApplyPhotonPFOCorrections} </parameter>
     <!--apply the corrected direction to the PFOs-->
-    <parameter name="modifyPFOdirection" type="bool">true </parameter>
+    <parameter name="modifyPFOdirection" type="bool"> ${ApplyPhotonPFOCorrections} </parameter>
     <!--nominal photon energy (for validation plots)-->
     <parameter name="nominalEnergy" type="float">200 </parameter>
     <!--produce validation plots-->


### PR DESCRIPTION
- This code is now ready for review.
- this is (should be) consistent with update of DDStripSplitter changes in https://github.com/iLCSoft/MarlinReco/pull/74

BEGINRELEASENOTES
- set up digi/reco/strip splitting for ScECAL
- updated ScECAL calibration
ENDRELEASENOTES