### PR TITLE
Muon issue: Pandora settings fix

### DIFF
--- a/StandardConfig/production/PandoraSettings/PandoraSettingsDefault.xml
+++ b/StandardConfig/production/PandoraSettings/PandoraSettingsDefault.xml
@@ -59,6 +59,8 @@
         <ReplacementCaloHitListName>MuonRemovedCaloHits</ReplacementCaloHitListName>
         <ReplaceCurrentClusterList>false</ReplaceCurrentClusterList>
         <ReplaceCurrentPfoList>false</ReplaceCurrentPfoList>
+        <!-- Default is 30. See https://github.com/iLCSoft/ILDConfig/pull/119 -->
+        <MaxClusterCaloHits> 100 </MaxClusterCaloHits>
     </algorithm>
 
     <!-- Standalone photon clustering -->

--- a/StandardConfig/production/PandoraSettings/PandoraSettingsDefault.xml
+++ b/StandardConfig/production/PandoraSettings/PandoraSettingsDefault.xml
@@ -61,6 +61,8 @@
         <ReplaceCurrentPfoList>false</ReplaceCurrentPfoList>
         <!-- Default is 30. See https://github.com/iLCSoft/ILDConfig/pull/119 -->
         <MaxClusterCaloHits> 100 </MaxClusterCaloHits>
+        <!-- Default is 7 GeV. See https://github.com/iLCSoft/ILDConfig/pull/119 -->
+        <MinTrackCandidateEnergy> 4 </MinTrackCandidateEnergy>
     </algorithm>
 
     <!-- Standalone photon clustering -->

--- a/StandardConfig/production/PandoraSettings/PandoraSettingsDefault_sdhcal.xml
+++ b/StandardConfig/production/PandoraSettings/PandoraSettingsDefault_sdhcal.xml
@@ -58,6 +58,8 @@
         <ReplaceCurrentPfoList>false</ReplaceCurrentPfoList>
         <!-- Default is 30. See https://github.com/iLCSoft/ILDConfig/pull/119 -->
         <MaxClusterCaloHits> 100 </MaxClusterCaloHits>
+        <!-- Default is 7 GeV. See https://github.com/iLCSoft/ILDConfig/pull/119 -->
+        <MinTrackCandidateEnergy> 4 </MinTrackCandidateEnergy>
     </algorithm>
 
     <!-- Standalone photon clustering -->

--- a/StandardConfig/production/PandoraSettings/PandoraSettingsDefault_sdhcal.xml
+++ b/StandardConfig/production/PandoraSettings/PandoraSettingsDefault_sdhcal.xml
@@ -56,6 +56,8 @@
         <ReplacementCaloHitListName>MuonRemovedCaloHits</ReplacementCaloHitListName>
         <ReplaceCurrentClusterList>false</ReplaceCurrentClusterList>
         <ReplaceCurrentPfoList>false</ReplaceCurrentPfoList>
+        <!-- Default is 30. See https://github.com/iLCSoft/ILDConfig/pull/119 -->
+        <MaxClusterCaloHits> 100 </MaxClusterCaloHits>
     </algorithm>
 
     <!-- Standalone photon clustering -->


### PR DESCRIPTION
BEGINRELEASENOTES
- Updated PandoraSettingsDefault.xml and PandoraSettingsDefault_sdhcal.xml
    - maximum cluster size in Yoke changed from 30 to 100 hits
    - changed MinTrackCandidateEnergy from 7 GeV to 4 GeV in muon reconstruction

ENDRELEASENOTES