### PR TITLE
Make the miniDST workflow more robust

### DIFF
--- a/StandardConfig/production/MarlinStdRecoMiniDST.xml
+++ b/StandardConfig/production/MarlinStdRecoMiniDST.xml
@@ -42,6 +42,7 @@
   <constant name="OutputFile" value="mini-DST.slcio"/>
   <constant name="ProductionDir" value="."/>
   <constant name="RundEdxCorrections" value="true"/>
+  <constant name="lcgeo_DIR" value=$lcgeo_DIR/>
 
   <constant name="LCFIPlusConfig_DIR" value="./LCFIPlusConfig"/>
   <constant name="LCFIPlusVertexPrefix" value="ildl5_4q250_ZZ"/>
@@ -56,7 +57,7 @@
 </constants>
 
 <processor name="InitDD4hep" type="InitializeDD4hep">
-  <parameter name="DD4hepXMLFile" type="string"> $lcgeo_DIR/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml </parameter>
+  <parameter name="DD4hepXMLFile" type="string"> ${lcgeo_DIR}/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml </parameter>
   <parameter name="Verbosity"> SILENT </parameter>
 </processor>
 

--- a/StandardConfig/production/run_standard_workflow.sh
+++ b/StandardConfig/production/run_standard_workflow.sh
@@ -77,7 +77,8 @@ LCTUPLE_CMD="Marlin MarlinStdRecoLCTuple.xml \
 
 MINIDST_CMD="Marlin MarlinStdRecoMiniDST.xml \
   --global.LCIOInputFiles=bbudsc_3evt_DST.slcio \
-  --constant.OutputFile=bbudsc_3evt_miniDST.slcio"
+  --constant.OutputFile=bbudsc_3evt_miniDST.slcio \
+  --constant.lcgeo_DIR=$lcgeo_DIR"
 
 clear_outputs
 run_cmd ddsim.out ${DDSIM_CMD}


### PR DESCRIPTION

BEGINRELEASENOTES
- Introduce the `lcgeo_DIR` constant into the mini-DST workflow. This makes it possible to set this value from the outside without having to rely on an envrionment variable being resolved automatically.

ENDRELEASENOTES

The `v02-02-02` version does not work inside a key4hep installation, because apparently environment variables are not automatically resolved. This could be due to a number of reasons, as quite a few packages are involved. Introducing the `lcgeo_DIR` constant (similar to `MarlinStdReco.xml`) allows to explicitly set this from the outside. 

iLCSoft `v02-02-02` still runs without `--constant.lcgeo_DIR=$lcgeo_DIR`.