### PR TITLE
Update steering file to be compatible with migrated track length code

### DIFF
--- a/StandardConfig/production/HighLevelReco/HighLevelReco.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.xml
@@ -305,6 +305,10 @@
   </processor>
 
 
+  <processor name="TrackLengthProcessor" type="TrackLengthProcessor">
+      <parameter name="ReconstructedParticleCollection" type="string" default="PandoraPFOs">PandoraPFOs</parameter>
+  </processor>
+
   <!--########## add TOF estimators for 0, 10 and 50 ps resolution  ###################################### -->
   <processor name="TOFEstimators0ps" type="TOFEstimators">
     <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->


### PR DESCRIPTION

BEGINRELEASENOTES

- Added TrackLength processor in the HighLevelReco chain.

ENDRELEASENOTES

This is dependency PR to make production steering file compatible with migrating TrackLength code from TOFEstimators to separate processor ( [PR 104)](https://github.com/iLCSoft/MarlinReco/pull/104).

There have been no changes to TOFEstimators steering parameters, so we need only to add the new TrackLength processor into the reconstruction chain