### PR TITLE
Digitisation and tracking steering files for the new ILD_l5_v09 model

### DIFF
--- a/StandardConfig/production/HighLevelReco/HighLevelReco_SiILD.xml
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco_SiILD.xml
@@ -1,0 +1,265 @@
+
+<group name="HighLevelReco">
+
+  <!--########## Add4MomCovMatrixCharged ###################################### -->
+  <!--Set the convariance matrix in (P,E) for all charged pfos in PandoraPFOs Collection-->
+  <processor name="MyAdd4MomCovMatrixCharged" type="Add4MomCovMatrixCharged">
+    <!--Name of the PandoraPFOs collection-->
+    <parameter name="InputPandoraPFOsCollection" type="String">PandoraPFOs</parameter>
+    <!--Verbosity lower than MESSAGE4 will print out cov. matrix for each pfo-->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE4 </parameter>
+  </processor>
+
+  <!--########## AddClusterProperties ###################################### -->
+  <processor name="MyAddClusterProperties" type="AddClusterProperties">
+    <parameter name="PFOCollectionName" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <parameter name="ClusterCollection" type="string" lcioInType="Cluster">PandoraClusters </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
+  </processor>
+
+
+  <processor name="MyComputeShowerShapesProcessor" type="ComputeShowerShapesProcessor">
+    <!--Performs Shower profile extraction-->
+    <!--Debugging?-->
+    <parameter name="Debug" type="int">0 </parameter>
+    <!--Name of the PFO collection-->
+    <parameter name="PFOCollection" type="string"> PandoraPFOs </parameter>
+    <!--Name of the Cluster collection-->
+    <parameter name="ClusterCollectionName" type="string"> PandoraClusters </parameter>
+    <!-- Radiation Length of Ecal-->
+    <parameter name="RadiationLength_Ecal" type="float">3.50 </parameter>
+    <!-- Radiation Length of Hcal-->
+    <parameter name="RadiationLength_Hcal" type="float">17.57 </parameter>
+    <!-- Moliere radius of Ecal-->
+    <parameter name="MoliereRadius_Ecal" type="float">9.00 </parameter>
+    <!-- Moliere radius of Hcal-->
+    <parameter name="MoliereRadius_Hcal" type="float">17.19 </parameter>
+  </processor>
+
+  <processor name="MyphotonCorrectionProcessor" type="photonCorrectionProcessor">
+    <!--photonCorrectionProcessor applies an energy correction to photon-like PFOs-->
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    <!--name of input PFO collection-->
+    <parameter name="inputCollection" type="string">PandoraPFOs </parameter>
+    <!--apply the corrected energies to the PFOs-->
+    <parameter name="modifyPFOenergies" type="bool"> ${ApplyPhotonPFOCorrections} </parameter>
+    <!--apply the corrected direction to the PFOs-->
+    <parameter name="modifyPFOdirection" type="bool"> ${ApplyPhotonPFOCorrections} </parameter>
+    <!--nominal photon energy (for validation plots)-->
+    <parameter name="nominalEnergy" type="float">200 </parameter>
+    <!--produce validation plots-->
+    <parameter name="validationPlots" type="bool">false </parameter>
+    <!-- the parameters for the various corrections -->
+    <parameter name="energyCor_Linearise"> 0.987 0.01426 </parameter>
+    <parameter name="energyCorr_barrelPhi"> 0.412249 0.0142289 -0.0933687 0.01345 0.0408156 </parameter>
+    <parameter name="energyCorr_costh"> -0.09 0. 0.235 0.007256 -0.0369648 0. 0.588 0.0121604 -0.0422968 0.774 0.009 1.002 </parameter>
+    <parameter name="energyCorr_endcap"> -0.025 855. 23. -0.07 1489. 18. </parameter>
+    <parameter name="phiCorr_barrel"> 2.36517e-05 1.32090e-04 -3.86883e+00 -1.67809e-01 2.28614e-05 6.03495e-05 0.419 0.00728 0.025 0.00 2.86667e-05 2.49371e-05 -7.71684e-06 -1.48118e-05 -5.63786e-06 -9.38376e-06 -4.96296e-06 2.91262e-06  </parameter>
+    <parameter name="thetaCorr_barrel"> -0.000166568 -7.119e-05 0.000223618 -3.95915e-05 </parameter>
+    <parameter name="thetaCorr_endcap"> 0.000129478 -3.73863e-05 -0.000847783 0.000153646 0.000806605 -0.000132608 </parameter>
+  </processor>
+
+  <processor name="MyV0Finder" type="V0Finder">
+    <parameter name="InputRecoParticleCollection" type="string"> PandoraPFOs </parameter>
+    <parameter name="TrackCollection" type="string"> MarlinTrkTracks </parameter>
+    <parameter name="MassRangeGamma"  type="float">  0.01 </parameter>
+    <parameter name="MassRangeK0S"    type="float">  0.1 </parameter>
+    <parameter name="MassRangeL0"     type="float">  0.1 </parameter>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG </parameter>
+  </processor>
+
+  <processor name="MyPi0Finder" type="GammaGammaCandidateFinder">
+    <parameter name="InputParticleCollectionName" value="PandoraPFOs" />
+    <parameter name="GammaGammaResonanceName" value="Pi0" />
+    <parameter name="GammaGammaResonanceMass" value="0.1349766" />
+    <parameter name="MaxDeltaMgg" value="0.04" />
+    <parameter name="GammaMomentumCut" value="0.5" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="GammaGammaCandidatePi0s" />
+  </processor>
+
+
+  <processor name="MyEtaFinder" type="GammaGammaCandidateFinder">
+    <parameter name="InputParticleCollectionName" value="PandoraPFOs" />
+    <parameter name="GammaGammaResonanceName" value="Eta" />
+    <parameter name="GammaGammaResonanceMass" value="0.547862" />
+    <parameter name="MaxDeltaMgg" value="0.14" />
+    <parameter name="GammaMomentumCut" value="1.0" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="GammaGammaCandidateEtas" />
+  </processor>
+
+
+  <processor name="MyEtaPrimeFinder" type="GammaGammaCandidateFinder">
+    <parameter name="InputParticleCollectionName" value="PandoraPFOs" />
+    <parameter name="GammaGammaResonanceName" value="EtaPrime" />
+    <parameter name="GammaGammaResonanceMass" value="0.95778" />
+    <parameter name="MaxDeltaMgg" value="0.19" />
+    <parameter name="GammaMomentumCut" value="2.0" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="GammaGammaCandidateEtaPrimes" />
+  </processor>
+
+
+  <processor name="MyGammaGammaSolutionFinder" type="GammaGammaSolutionFinder">
+    <parameter name="InputParticleCollectionName1" value="GammaGammaCandidatePi0s" />
+    <parameter name="InputParticleCollectionName2" value="GammaGammaCandidateEtas" />
+    <parameter name="InputParticleCollectionName3" value="GammaGammaCandidateEtaPrimes" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="GammaGammaParticles" />
+  </processor>
+
+
+  <processor name="MyDistilledPFOCreator" type="DistilledPFOCreator">
+    <parameter name="InputParticleCollectionName1" value="PandoraPFOs" />
+    <parameter name="InputParticleCollectionName2" value="GammaGammaParticles" />
+    <parameter name="Printing" value="0" />
+    <parameter name="OutputParticleCollectionName" value="DistilledPFOs" />
+  </processor>
+
+
+  <processor name="MyLikelihoodPID" type="LikelihoodPIDProcessor">
+    <!--Performs particle identification-->
+    <!--Debugging?-->
+    <parameter name="Debug" type="int">1 </parameter>
+    <!--Boundaries for energy binning-->
+    <parameter name="EnergyBoundaries" type="FloatVec">0 1.0e+07  </parameter>
+    <!--Name of files containing pdfs for charged particles-->
+    <parameter name="FilePDFName" type="StringVec"> ${PidPDFFile} </parameter>
+    <!--Whether MVA low momentum mu/pi is used or not-->
+    <parameter name="UseLowMomentumMuPiSeparation" type="bool"> true </parameter>
+    <!--The BDTG weights files for low momentum mu/pi separation-->
+    <parameter name="FileWeightFormupiSeparationName" type="StringVec"> ${PidWeightFiles} </parameter>
+
+    <!--dE/dx parameters for each particle-->
+    <parameter name="dEdxParameter_electron" type="FloatVec">
+      -1.28883368e-02  2.72959919e+01  1.10560871e+01 -1.74534200e+00 -9.84887586e-07
+    </parameter>
+    <parameter name="dEdxParameter_muon" type="FloatVec">
+      6.49143971e-02 1.55775592e+03 9.31848047e+08 2.32201725e-01 2.50492066e-04
+    </parameter>
+    <parameter name="dEdxParameter_pion" type="FloatVec">
+      6.54955215e-02  8.26239081e+06  1.92933904e+05 2.52743206e-01 2.26657525e-04
+    </parameter>
+    <parameter name="dEdxParameter_kaon" type="FloatVec">
+      7.52235689e-02 1.59710415e+04 1.79625604e+06 3.15315795e-01 2.30414997e-04
+    </parameter>
+    <parameter name="dEdxParameter_proton" type="FloatVec">
+      7.92251260e-02 6.38129720e+04 3.82995071e+04 2.80793601e-01 7.14371743e-04
+    </parameter>
+
+    <!--dE/dx normalization-->
+    <parameter name="dEdxNormalization" type="float"> 1.350e-7 </parameter>
+    <!--dE/dx error factor(7.55 for l5, 8.53 for s5)-->
+    <parameter name="dEdxErrorFactor" type="float"> ${dEdXErrorFactor} </parameter>
+    <!-- Method: Maximum Likelihood(0), Bayesian(1), or risk based Bayesian(2)-->
+    <parameter name="UseBayesian" type="int"> 2 </parameter>
+
+    <!-- Cost Matrix for risk based Bayesian(2)-->
+    <parameter name="CostMatrix" type="FloatVec">
+      1.0e-50 1.0 1.5 1.0 1.5
+      1.0 1.0e-50 3.0 1.0 1.0
+      1.0 1.0 1.0e-50 1.0 3.0
+      1.0 1.0 4.0 1.0e-50 2.0
+      1.0 1.0 5.0 1.0 1.0e-50
+    </parameter>
+
+    <!--Name of the PFO collection-->
+    <parameter name="RecoParticleCollection" type="string">PandoraPFOs</parameter>
+  </processor>
+
+
+  <processor name="MyRecoMCTruthLinker" type="RecoMCTruthLinker">
+    <!--links RecontructedParticles to the MCParticle based on number of hits used-->
+    <!--energy cut for Brems that are kept-->
+    <parameter name="BremsstrahlungEnergyCut" type="float">1 </parameter>
+    <!--Name of the updated calo-hit MCTruthLink output collection - not created if empty()-->
+    <parameter name="CalohitMCTruthLinkName" type="string" lcioOutType="LCRelation"> CalohitMCTruthLink </parameter>
+    <!--Name of the Clusters input collection-->
+    <parameter name="ClusterCollection" type="string" lcioInType="Cluster">PandoraClusters </parameter>
+    <!--Name of the clusterMCTruthLink output collection - not created if empty()-->
+    <parameter name="ClusterMCTruthLinkName" type="string" lcioOutType="LCRelation"> ClusterMCTruthLink </parameter>
+    <!--true: All reco <-> true relations are given, with weight = 10000*calo
+	weight+track weight (weights in permill). false: Only highest contributor
+	linked,and only to tracks, not clusters if there are any tracks-->
+    <parameter name="FullRecoRelation" type="bool">false </parameter>
+    <!--Work-around Mokka bug in vertex-is-not-endpoint-of-parent flag (logic inverted)-->
+    <parameter name="InvertedNonDestructiveInteractionLogic" type="bool"> false </parameter>
+    <!--PDG codes of particles of which the daughters will be kept in the skimmmed MCParticle collection-->
+    <!-- FIXME:Check if we really want to keep those -->
+    <parameter name="KeepDaughtersPDG" type="IntVec">22 111 310 13 211 321 3120 </parameter>
+    <!--Name of the MCParticle input collection-->
+    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCParticle </parameter>
+    <!--Name of the skimmed MCParticle  output collection - not created if empty()-->
+    <parameter name="MCParticlesSkimmedName" type="string" lcioOutType="MCParticle"> MCParticlesSkimmed </parameter>
+    <!--Name of the MCTruthClusterLink output collection-->
+    <parameter name="MCTruthClusterLinkName" type="string" lcioOutType="LCRelation"> </parameter>
+    <!--Name of the MCTruthRecoLink output collection-->
+    <parameter name="MCTruthRecoLinkName" type="string" lcioOutType="LCRelation"> </parameter>
+    <!--Name of the trackMCTruthLink output collection-->
+    <parameter name="MCTruthTrackLinkName" type="string" lcioOutType="LCRelation"> </parameter>
+    <!--Name of the RecoMCTruthLink output collection - not created if empty()-->
+    <parameter name="RecoMCTruthLinkName" type="string" lcioOutType="LCRelation"> RecoMCTruthLink </parameter>
+    <!--Name of the ReconstructedParticles input collection-->
+    <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle"> MergedRecoParticles </parameter>
+    <!--save photons from Brems-->
+    <parameter name="SaveBremsstrahlungPhotons" type="bool">false </parameter>
+    <!--Names of the SimCaloHits input collections-->
+    <parameter name="SimCaloHitCollections" type="StringVec" lcioInType="SimCalorimeterHit">
+      BeamCalCollection
+      LHCalCollection
+      LumiCalCollection
+      ${ECalSimHitCollections}
+      ${HCalSimHitCollections}
+      YokeBarrelCollection
+      YokeEndcapsCollection
+    </parameter>
+    <!--Name of the  lcrelation collections, that link the SimCalorimeterHit to CalorimeterHit-->
+    <parameter name="SimCalorimeterHitRelationNames" type="StringVec" lcioInType="LCRelation">
+      EcalBarrelRelationsSimRec
+      EcalEndcapRingRelationsSimRec
+      EcalEndcapsRelationsSimRec
+      HcalBarrelRelationsSimRec
+      HcalEndcapRingRelationsSimRec
+      HcalEndcapsRelationsSimRec
+      RelationLHcalHit
+      RelationMuonHit
+      RelationLcalHit
+      RelationBCalHit
+    </parameter>
+    <!--Names of the SimTrackerHits input collection-->
+    <parameter name="SimTrackerHitCollections" type="StringVec" lcioInType="SimTrackerHit">
+      VXDCollection
+      FTD_PIXELCollection
+      SITCollection
+      OuterTrackerBarrelCollection
+      FTD_STRIPCollection
+      OuterTrackerEndcapCollection
+    </parameter>
+    <!--Name of the Tracks input collection-->
+    <parameter name="TrackCollection" type="string" lcioInType="Track"> SiTracks </parameter>
+    <!--Name of the trackMCTruthLink output collection - not created if empty()-->
+    <parameter name="MCTruthTrackLinkName" type="string" lcioOutType="LCRelation"> MCTruthSiTracksLink </parameter>
+    <parameter name="TrackMCTruthLinkName" type="string" lcioOutType="LCRelation"> SiTracksMCTruthLink </parameter>
+    <!--Name of the lcrelation collections, that link the TrackerHits to their SimTrackerHits.-->
+    <parameter name="TrackerHitsRelInputCollections" type="StringVec" lcioInType="LCRelation">
+      VXDTrackerHitRelations
+      FTDPixelTrackerHitRelations
+      SITTrackerHitRelations
+      OuterTrackerBarrelHitsRelations
+      FTDStripTrackerHitRelations
+      OuterTrackerEndcapHitsRelations
+    </parameter>
+    <!--true: use relations for TrackerHits, false : use getRawHits -->
+    <parameter name="UseTrackerHitRelations" type="bool"> true </parameter>
+    <!--If Using Particle Gun Ignore Gen Stat-->
+    <parameter name="UsingParticleGun" type="bool"> false </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+    <!--energy cut for daughters that are kept from KeepDaughtersPDG-->
+    <parameter name="daughtersECutMeV" type="float"> 10 </parameter>
+  </processor>
+
+</group>

--- a/StandardConfig/production/ParticleFlow/PandoraPFA_SiILD.xml
+++ b/StandardConfig/production/ParticleFlow/PandoraPFA_SiILD.xml
@@ -1,0 +1,82 @@
+
+
+<group name="ParticleFlow">
+
+  <processor name="MyDDMarlinPandora" type="DDPandoraPFANewProcessor">
+    <!--Track cut on distance from BarrelTracker inner r to id whether track can form pfo-->
+    <parameter name="MaxBarrelTrackerInnerRDistance" type="float">105.0 </parameter>
+    <parameter name="PandoraSettingsXmlFile" type="String"> ${PandoraSettingsFile} </parameter>
+    <parameter name="UseDD4hepField" type="bool">false</parameter>
+    <!-- Collection names -->
+    <parameter name="TrackCollections" type="StringVec">SiTracks</parameter>
+    <parameter name="ECalCaloHitCollections" type="StringVec">EcalBarrelCollectionRec EcalBarrelCollectionGapHits EcalEndcapsCollectionRec EcalEndcapsCollectionGapHits EcalEndcapRingCollectionRec</parameter>
+    <parameter name="HCalCaloHitCollections" type="StringVec">HcalBarrelCollectionRec HcalEndcapsCollectionRec HcalEndcapRingCollectionRec</parameter>
+    <parameter name="LCalCaloHitCollections" type="StringVec">LCAL</parameter>
+    <parameter name="LHCalCaloHitCollections" type="StringVec">LHCAL</parameter>
+    <parameter name="MuonCaloHitCollections" type="StringVec">MUON</parameter>
+    <parameter name="MCParticleCollections" type="StringVec">MCParticle</parameter>
+    <parameter name="RelCaloHitCollections" type="StringVec">EcalBarrelRelationsSimRec EcalEndcapsRelationsSimRec EcalEndcapRingRelationsSimRec HcalBarrelRelationsSimRec HcalEndcapsRelationsSimRec HcalEndcapRingRelationsSimRec RelationMuonHit RelationLHcalHit RelationLcalHit</parameter>
+    <parameter name="RelTrackCollections" type="StringVec">SiTracksMCP</parameter>
+    <parameter name="KinkVertexCollections" type="StringVec">KinkVertices</parameter>
+    <parameter name="ProngVertexCollections" type="StringVec">ProngVertices</parameter>
+    <parameter name="SplitVertexCollections" type="StringVec">SplitVertices</parameter>
+    <parameter name="V0VertexCollections" type="StringVec">V0Vertices</parameter>
+    <parameter name="StartVertexCollectionName" type="string">PandoraPFANewStartVertices</parameter>
+    <parameter name="StartVertexAlgorithmName" type="string">PandoraPFANew</parameter>
+    <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
+    <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
+    <!-- Calibration constants -->
+    <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+    <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+    <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
+    <parameter name="ECalMipThreshold" type="float">0.5</parameter>
+    <parameter name="HCalMipThreshold" type="float">0.3</parameter>
+    <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+    <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+    <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+    <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+    <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
+    <parameter name="DigitalMuonHits" type="int">0</parameter>
+    <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
+    <parameter name="SoftwareCompensationWeights" type="FloatVec"> ${PandoraSoftwareCompensationWeights} </parameter>
+    <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0  2  5  7.5  9.5  13  16  20  23.5  28</parameter>
+    <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
+    <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
+    <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
+    <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
+    <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>
+
+    <!--Whether to calculate track states manually, rather than copy stored fitter values-->
+    <parameter name="UseOldTrackStateCalculation" type="int"> 0 1  </parameter> <!-- !!!FIXME, workaround for some missing TS AtCalo face - this should really be: 0 -->
+    <parameter name="NEventsToSkip" type="int">0</parameter>
+    <!--parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG0 </parameter-->
+    <!--The name of the Vertex Barrel detector-->
+    <parameter name="VertexBarrelDetectorName" type="string">VXD </parameter>
+    <!--Detector names of the Trackers in the Barrel starting from the innermost one-->
+    <parameter name="TrackerBarrelDetectorNames" type="StringVec">OuterTrackers</parameter>
+    <!--Detector names of the Trackers in the Endcap starting from the innermost one-->
+    <parameter name="TrackerEndcapDetectorNames" type="StringVec">FTD</parameter>
+    <parameter name="CoilName" type="string">Coil</parameter>
+    <parameter name="ECalBarrelDetectorName" type="string">EcalBarrel </parameter>
+    <parameter name="ECalEndcapDetectorName" type="string">EcalEndcap </parameter>
+    <parameter name="ECalOtherDetectorNames" type="StringVec">EcalPlug Lcal BeamCal  </parameter>
+    <parameter name="HCalEndcapDetectorName" type="string">HcalEndcap </parameter>
+    <parameter name="HCalBarrelDetectorName" type="string">HcalBarrel </parameter>
+    <parameter name="HCalOtherDetectorNames" type="StringVec">HcalRing LHcal </parameter>
+    <parameter name="MuonBarrelDetectorName" type="string">YokeBarrel </parameter>
+    <parameter name="MuonEndcapDetectorName" type="string">YokeEndcap </parameter>
+    <parameter name="MuonOtherDetectorNames" type="StringVec"></parameter>
+    <!--Decides whether to create gaps in the geometry (ILD-specific)-->
+    <!---SHOULD BE TRUE FOR ILD BUT INNER/OUTER SYMMETRIES ARE NOT COMPATIBLE -->
+    <parameter name="CreateGaps" type="bool">false</parameter>
+
+    <!-- RE: Fix for driver Yoke05_Barrel in lcgeo. See PR #241 iLCSoft/lcgeo -->
+    <!-- The layers are oriented in (0,1,0) before placement in the stave/module -->
+    <parameter name="YokeBarrelNormalVector" type="FloatVec">0 1 0 </parameter>
+
+    <!--The name of the DDTrackCreator implementation-->
+    <parameter name="TrackCreatorName" type="string">DDTrackCreatorCLIC </parameter>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> SILENT </parameter>
+  </processor>
+
+</group>

--- a/StandardConfig/production/README.md
+++ b/StandardConfig/production/README.md
@@ -171,3 +171,11 @@ ls GeneratedFiles
 # -> MarlinStdReco_ILD_l5_o1_v02.xml  MarlinStdReco_ILD_l5_o2_v02.xml  MarlinStdReco_ILD_s5_o1_v02.xml  MarlinStdReco_ILD_s5_o2_v02.xml
 ```
 
+## Running the full reconstruction chain with all silicon ILD model
+
+In order to run the standard full reconstruction with the ILD_l5_v09 model, in the *MarlinStdReco.xml* file:
+
+- replace TrackingDigi and TrackingReco groups in the ```<execute>``` section by SiliconTrackingDigi and ConformalTrackingReco
+- include *Tracking/TrackingDigi_SiILD.xml*, *Tracking/ConformalTracking_SiILD.xml*, *HighLevelReco/HighLevelReco_SiILD.xml*, *ParticleFlow/PandoraPFA_SiILD.xml* files instead of the respective default ones
+
+Then run the reconstruction as described above, providing the proper detector model.

--- a/StandardConfig/production/README.md
+++ b/StandardConfig/production/README.md
@@ -173,9 +173,10 @@ ls GeneratedFiles
 
 ## Running the full reconstruction chain with all silicon ILD model
 
-In order to run the standard full reconstruction with the ILD_l5_v09 model, in the *MarlinStdReco.xml* file:
+In order to run the standard full reconstruction with the ILD_l5_v09 model, in the `MarlinStdReco.xml` file:
 
-- replace TrackingDigi and TrackingReco groups in the ```<execute>``` section by SiliconTrackingDigi and ConformalTrackingReco
-- include *Tracking/TrackingDigi_SiILD.xml*, *Tracking/ConformalTracking_SiILD.xml*, *HighLevelReco/HighLevelReco_SiILD.xml*, *ParticleFlow/PandoraPFA_SiILD.xml* files instead of the respective default ones
+- replace `TrackingDigi` and `TrackingReco` groups in the ```<execute>``` section by `SiliconTrackingDigi` and `ConformalTrackingReco`
+- include `Tracking/TrackingDigi_SiILD.xml`, `Tracking/ConformalTracking_SiILD.xml`, `HighLevelReco/HighLevelReco_SiILD.xml`, `ParticleFlow/PandoraPFA_SiILD.xml` files instead of the respective default ones
+- Make sure to pass the right compact file with the ILD_l5_v09 model definition.
 
 Then run the reconstruction as described above, providing the proper detector model.

--- a/StandardConfig/production/Tracking/ConformalTracking_SiILD.xml
+++ b/StandardConfig/production/Tracking/ConformalTracking_SiILD.xml
@@ -1,0 +1,130 @@
+
+<group name="ConformalTrackingReco">
+
+    <!-- == Pattern recognition parameters == -->
+    <processor name="MyConformalTracking" type="ConformalTrackingV2">
+      <!--ConformalTracking constructs tracks using a combined conformal mapping and cellular automaton approach.-->
+
+      <!--Name of the TrackerHit input collections-->
+      <parameter name="TrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane"> VXDTrackerHits FTDPixelTrackerHits FTDStripTrackerHits SITTrackerHits OTrackerHits OTrackerEndcapHits </parameter>
+      <!--Name of the MCParticle input collection-->
+      <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
+      <!--Name of the TrackerHit relation collections-->
+      <parameter name="RelationsNames" type="StringVec" lcioInType="LCRelation"> VXDTrackerHitRelations FTDPixelTrackerHitRelations FTDStripTrackerHitRelations SITTrackerHitRelations OuterTrackerBarrelHitsRelations OuterTrackerEndcapHitsRelations </parameter>
+      <!--Silicon track Collection Name-->
+      <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracksCT </parameter>
+      <!--Debug hits Collection Name-->
+      <parameter name="DebugHits" type="string" lcioOutType="TrackerHitPlane"> DebugHits </parameter>
+      <!--Maximum number of track hits to try the inverted fit-->
+      <parameter name="MaxHitInvertedFit" type="int">0 </parameter>
+      <!--Final minimum number of track clusters-->
+      <parameter name="MinClustersOnTrackAfterFit" type="int">3 </parameter>
+
+      <!--enable debug plots -->
+      <parameter name="DebugPlots" type="bool"> false </parameter>
+      <!--Purity value used for checking if tracks are real or not-->
+      <parameter name="trackPurity" type="double">0.7 </parameter>
+      <!--Print out time profile - for some, verbosity must be enable-->
+      <parameter name="DebugTiming" type="bool">false </parameter>
+      <!--retry with tightened parameters, when too many tracks are being created-->
+      <parameter name="RetryTooManyTracks" type="bool">false </parameter>
+      <!--Number of tracks that is considered too many-->
+      <parameter name="TooManyTracks" type="int">100000 </parameter>
+      <!--sort results from kdtree search-->
+      <parameter name="SortTreeResults" type="bool">true </parameter>
+
+      <!--steps for the pattern recognition-->
+      <parameter name="Steps" type="StringVec">
+        [VXDBarrel]
+        @Collections : VXDTrackerHits
+        @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 10.0;
+        @Flags : HighPTFit, VertexToTracker
+        @Functions : CombineCollections, BuildNewTracks
+        [VXDEncap]
+        @Collections : FTDPixelTrackerHits
+        @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 0.0;
+        @Flags : HighPTFit, VertexToTracker
+        @Functions : CombineCollections, ExtendTracks
+        [LowerCellAngle1]
+        @Collections : VXDTrackerHits, FTDPixelTrackerHits
+        @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 10.0;
+        @Flags : HighPTFit, VertexToTracker, RadialSearch
+        @Functions : CombineCollections, BuildNewTracks
+        [LowerCellAngle2]
+        @Collections :
+        @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 10.0;
+        @Flags : HighPTFit, VertexToTracker, RadialSearch
+        @Functions : BuildNewTracks, SortTracks
+        [Tracker]
+        @Collections : SITTrackerHits, FTDStripTrackerHits, OTrackerHits, OTrackerEndcapHits
+        @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.1; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 0.0;
+        @Flags : HighPTFit, VertexToTracker, RadialSearch
+        @Functions : CombineCollections, BuildNewTracks
+        [Displaced]
+        @Collections : VXDTrackerHits, FTDPixelTrackerHits, SITTrackerHits, FTDStripTrackerHits, OTrackerHits, OTrackerEndcapHits
+        @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015; SlopeZRange: 10.0; HighPTCut: 10.0;
+        @Flags : OnlyZSchi2cut, RadialSearch
+        @Functions : CombineCollections, BuildNewTracks
+      </parameter>
+
+      <!--Angular range for initial cell seeding-->
+      <parameter name="ThetaRange" type="double"> 0.05 </parameter>
+
+      <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+      <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    </processor>
+
+
+    <processor name="ClonesAndSplitTracksFinder" type="ClonesAndSplitTracksFinder">
+      <parameter name="InputTrackCollectionName" type="string"> SiTracksCT </parameter>
+      <parameter name="OutputTrackCollectionName" type="string"> SiTracks </parameter>
+      <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
+      <parameter name="EnergyLossOn" type="bool"> true </parameter>
+      <parameter name="SmoothOn" type="bool"> false </parameter>
+      <parameter name="extrapolateForward" type="bool"> true </parameter>
+      <!--if true, the merging of split tracks is performed-->
+      <parameter name="mergeSplitTracks" type="bool">true  </parameter>
+      <!--minimum track pt for merging (in GeV/c)-->
+      <parameter name="minTrackPt" type="double">1 </parameter>
+      <!--maximum significance separation in phi-->
+      <parameter name="maxSignificancePhi" type="double">3 </parameter>
+      <!--maximum significance separation in pt-->
+      <parameter name="maxSignificancePt" type="double">2 </parameter>
+      <!--maximum significance separation in tanLambda-->
+      <parameter name="maxSignificanceTheta" type="double">3 </parameter>
+    </processor>
+
+
+    <processor name="Refit" type="RefitFinal">
+      <!--Refit processor that calls finaliseLCIOTrack after taking the trackstate from the existing track. No re-sorting of hits is done-->
+      <!--Use Energy Loss in Fit-->
+      <parameter name="EnergyLossOn" type="bool"> true </parameter>
+      <!--Name of the input track to MCParticle relation collection-->
+      <parameter name="InputRelationCollectionName" type="string" lcioInType="LCRelation"> SiTrackRelations </parameter>
+      <!--Name of the input track collection-->
+      <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
+      <!--maximum allowable chi2 increment when moving from one site to another-->
+      <parameter name="Max_Chi2_Incr" type="double"> 1.79769e+30 </parameter>
+      <!--Use MultipleScattering in Fit-->
+      <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
+      <!--Refit Track to MCParticle relation collection Name-->
+      <parameter name="OutputRelationCollectionName" type="string" lcioOutType="LCRelation">
+        SiTracks_Refitted_Relation
+      </parameter>
+      <!--Name of the output track collection-->
+      <parameter name="OutputTrackCollectionName" type="string" lcioOutType="Track">
+        SiTracks_Refitted
+      </parameter>
+      <!--Identifier of the reference point to use for the fit initialisation, -1 means at 0 0 0-->
+      <parameter name="ReferencePoint" type="int"> -1 </parameter>
+      <!--Smooth All Mesurement Sites in Fit-->
+      <parameter name="SmoothOn" type="bool"> false </parameter>
+      <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+      <!--parameter name="Verbosity" type="string"> DEBUG </parameter-->
+      <!--if true extrapolation in the forward direction (in-out), otherwise backward (out-in)-->
+      <parameter name="extrapolateForward" type="bool"> true </parameter>
+      <!--Final minimum number of track clusters-->
+      <parameter name="MinClustersOnTrackAfterFit" type="int">3 </parameter>
+    </processor>
+
+</group>

--- a/StandardConfig/production/Tracking/ConformalTracking_SiILD.xml
+++ b/StandardConfig/production/Tracking/ConformalTracking_SiILD.xml
@@ -12,11 +12,11 @@
       <!--Name of the TrackerHit relation collections-->
       <parameter name="RelationsNames" type="StringVec" lcioInType="LCRelation"> VXDTrackerHitRelations FTDPixelTrackerHitRelations FTDStripTrackerHitRelations SITTrackerHitRelations OuterTrackerBarrelHitsRelations OuterTrackerEndcapHitsRelations </parameter>
       <!--Silicon track Collection Name-->
-      <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracksCT </parameter>
+      <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track"> SiTracksCT </parameter>
       <!--Debug hits Collection Name-->
       <parameter name="DebugHits" type="string" lcioOutType="TrackerHitPlane"> DebugHits </parameter>
       <!--Maximum number of track hits to try the inverted fit-->
-      <parameter name="MaxHitInvertedFit" type="int">0 </parameter>
+      <parameter name="MaxHitInvertedFit" type="int"> 6 </parameter>
       <!--Final minimum number of track clusters-->
       <parameter name="MinClustersOnTrackAfterFit" type="int">3 </parameter>
 
@@ -37,32 +37,32 @@
       <parameter name="Steps" type="StringVec">
         [VXDBarrel]
         @Collections : VXDTrackerHits
-        @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 10.0;
+        @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.04; SlopeZRange: 10.0; HighPTCut: 10.0;
         @Flags : HighPTFit, VertexToTracker
         @Functions : CombineCollections, BuildNewTracks
         [VXDEncap]
         @Collections : FTDPixelTrackerHits
-        @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 0.0;
+        @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.04; SlopeZRange: 10.0; HighPTCut: 0.0;
         @Flags : HighPTFit, VertexToTracker
         @Functions : CombineCollections, ExtendTracks
         [LowerCellAngle1]
         @Collections : VXDTrackerHits, FTDPixelTrackerHits
-        @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 10.0;
+        @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.04; SlopeZRange: 10.0; HighPTCut: 10.0;
         @Flags : HighPTFit, VertexToTracker, RadialSearch
         @Functions : CombineCollections, BuildNewTracks
         [LowerCellAngle2]
         @Collections :
-        @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 10.0;
+        @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.04; SlopeZRange: 10.0; HighPTCut: 10.0;
         @Flags : HighPTFit, VertexToTracker, RadialSearch
         @Functions : BuildNewTracks, SortTracks
         [Tracker]
         @Collections : SITTrackerHits, FTDStripTrackerHits, OTrackerHits, OTrackerEndcapHits
-        @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.1; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 0.0;
+        @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.1; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.04; SlopeZRange: 10.0; HighPTCut: 0.0;
         @Flags : HighPTFit, VertexToTracker, RadialSearch
-        @Functions : CombineCollections, BuildNewTracks
+        @Functions : CombineCollections, ExtendTracks
         [Displaced]
         @Collections : VXDTrackerHits, FTDPixelTrackerHits, SITTrackerHits, FTDStripTrackerHits, OTrackerHits, OTrackerEndcapHits
-        @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015; SlopeZRange: 10.0; HighPTCut: 10.0;
+        @Parameters : MaxCellAngle : 0.1; MaxCellAngleRZ : 0.1; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.035; SlopeZRange: 10.0; HighPTCut: 10.0;
         @Flags : OnlyZSchi2cut, RadialSearch
         @Functions : CombineCollections, BuildNewTracks
       </parameter>
@@ -92,6 +92,9 @@
       <parameter name="maxSignificancePt" type="double">2 </parameter>
       <!--maximum significance separation in tanLambda-->
       <parameter name="maxSignificanceTheta" type="double">3 </parameter>
+
+      <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+      <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
     </processor>
 
 

--- a/StandardConfig/production/Tracking/TrackingDigi_SiILD.xml
+++ b/StandardConfig/production/Tracking/TrackingDigi_SiILD.xml
@@ -1,0 +1,145 @@
+
+
+<group name="SiliconTrackingDigi">
+
+  <processor name="MySplitCollectionByLayer" type="SplitCollectionByLayer">
+    <!--split a hit collection based on the layer number of the hits -->
+    <!--Name of the input collection with hits-->
+    <parameter name="InputCollection" type="string">FTDCollection </parameter>
+    <!--Name of the output collection with start and end layer number-->
+    <parameter name="OutputCollections" type="StringVec">FTD_PIXELCollection 0 1 FTD_STRIPCollection 2 6  </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> > -->
+  </processor>
+
+
+  <processor name="VXDPlanarDigiProcessor_CMOSVXD5" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> VXD </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float"> 0.003 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float"> 0.003  </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">VXDCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">VXDTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">VXDTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+  </processor>
+
+
+  <processor name="SITPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> SIT </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool"> false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float">0.005 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float">0.005 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">SITCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">SITTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">SITTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+  </processor>
+
+
+  <processor name="FTDPixelPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> FTD </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float">0.003 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float">0.003 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit"> FTD_PIXELCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">FTDPixelTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">FTDPixelTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+  </processor>
+
+
+  <processor name="FTDStripPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--Project hits onto the surface in case they are not yet on the surface (default: false)-->
+    <parameter name="ForceHitsOntoSurface" type="bool">true </parameter>
+
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> FTD </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool">false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float">0.007 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float">0.0 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">FTD_STRIPCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">FTDStripTrackerHitRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">FTDStripTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+  </processor>
+
+  <processor name="OuterPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> OuterTrackers </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool"> false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float"> 0.007</parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float"> 0.09 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">OuterTrackerBarrelCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">OuterTrackerBarrelHitsRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">OTrackerHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+  </processor>
+
+  <processor name="OuterEndcapPlanarDigiProcessor" type="DDPlanarDigiProcessor">
+    <!--PlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.-->
+    <parameter name="SubDetectorName" type="string"> OuterTrackers </parameter>
+    <!--whether hits are 1D strip hits-->
+    <parameter name="IsStrip" type="bool"> false </parameter>
+    <!--resolution in direction of u-->
+    <parameter name="ResolutionU" type="float"> 0.007 </parameter>
+    <!--resolution in direction of v-->
+    <parameter name="ResolutionV" type="float"> 0.09 </parameter>
+    <!--Name of the Input SimTrackerHit collection-->
+    <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">OuterTrackerEndcapCollection </parameter>
+    <!--Name of TrackerHit SimTrackHit relation collection-->
+    <parameter name="SimTrkHitRelCollection" type="string" lcioOutType="LCRelation">OuterTrackerEndcapHitsRelations </parameter>
+    <!--Name of the TrackerHit output collection-->
+    <parameter name="TrackerHitCollectionName" type="string" lcioOutType="TrackerHitPlane">OTrackerEndcapHits </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+  </processor>
+
+</group>


### PR DESCRIPTION

BEGINRELEASENOTES
- Digitisation including the hits from CLIC-like outer tracker and changes for the FTD, allowing for further use of the Conformal Tracking
- Conformal tracking with input collections from the new ILD_l5_v09 model, parameters setup as in CLIC config.

ENDRELEASENOTES

This is still work in progress, requires e.g. some further parameter tuning, but I was suggested to share these files (which of course makes a lot of sense).