### PR TITLE
Allows to run standard reconstruction with perfect PFA

### DIFF
--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -46,6 +46,9 @@
     <!--The BeamCal calibration constant, sim hit energy to calibrated calo hit energy-->
     <constant name="BeamCalCalibrationFactor">79.6</constant>
     
+    <!--Flag to run differently the PFA, use value Perfect to run MCtruePFA-->
+    <constant name="PFAtype" value="" />
+    
     <!-- ***** Input files constants ***** -->        
     <!-- Geometry model dependant calibration constants from external file -->
     <include ref="${CalibrationFile}" />
@@ -194,7 +197,7 @@
   <include ref="CaloDigi/MuonDigi.xml" />
   
   <!-- Particle Flow reconstruction : PandoraPFA -->
-  <include ref="ParticleFlow/PandoraPFA.xml" />
+  <include ref="ParticleFlow/PandoraPFA${PFAtype}.xml" />
   
   <!-- Standalone BeamCal reconstruction -->
   <include ref="HighLevelReco/BeamCalReco.xml" />

--- a/StandardConfig/production/ParticleFlow/PandoraPFAPerfect.xml
+++ b/StandardConfig/production/ParticleFlow/PandoraPFAPerfect.xml
@@ -1,0 +1,165 @@
+
+
+<group name="ParticleFlow">
+
+    <processor name="MyRecoMCTruthLinkerPass1" type="RecoMCTruthLinker">
+    <!--links RecontructedParticles to the MCParticle based on number of hits used-->
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING0  </parameter>  -->
+    <!--  Input collections: mcparticles, pfos, clusters and tracks 
+          PFOs already connect to tracks and clusters, so what we do in this processor is to connect
+          tracks and clusters to mcparticles ... 
+          The values given here are the defaults, so they don't really need to be
+          specified -->
+    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCParticle </parameter>
+    <!--Name of the ReconstructedParticles input collection-->
+    <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle">  </parameter>
+    <!--Name of the Cluster collection -->
+    <parameter name="ClusterCollection" type="string" lcioInType="Cluster">  </parameter>
+    <!--Name of the Tracks input collection-->
+    <parameter name="TrackCollection" type="string" lcioInType="Track">MarlinTrkTracks </parameter>
+    
+    <!-- Don't change any of these hit related collections if you're not very sure you know what you are doing.
+         In any case, the ones listed here are the defaults, so they can be removed from
+         this steering -->
+    <!--  Simulated tracker hits (has the conection to MCParticles -->
+    <parameter name="SimTrackerHitCollections" type="StringVec" lcioInType="SimTrackerHit">
+      VXDCollection 
+      SITCollection 
+      FTD_PIXELCollection 
+      FTD_STRIPCollection 
+      TPCCollection 
+      SETCollection  
+    </parameter>
+    <!--  Connections from tracker hits (connected to tracks) to sim tracker hits (connects to MC particle) -->
+    <parameter name="TrackerHitsRelInputCollections" type="StringVec" lcioInType="LCRelation">
+      VXDTrackerHitRelations 
+      SITTrackerHitRelations
+      FTDPixelTrackerHitRelations 
+      FTDSpacePointRelations 
+      TPCTrackerHitRelations 
+      SETSpacePointRelations  
+    </parameter>
+    <!-- same for the calos: Simulated calo hits (has the connection to MCParticles) -->
+    <parameter name="SimCaloHitCollections" type="StringVec" lcioInType="SimCalorimeterHit">
+    </parameter> 
+    <!-- Connections from calo hist (connected to clusters) tp sim calo hits  (connects to MC particle) -->
+    <parameter name="SimCalorimeterHitRelationNames" type="StringVec" lcioInType="LCRelation">
+    </parameter> 
+    
+    <!--PDG codes of particles of which the daughters will be kept in the skimmmed MCParticle collection-->
+    <parameter name="KeepDaughtersPDG" type="IntVec"> 22 111 310 13 211 321</parameter>
+    
+    <!--Names of the output collections -->
+    <!--Name of the skimmed MCParticle  output collection-->
+    <parameter name="MCParticlesSkimmedName" type="string" lcioOutType="MCParticle"> MCParticlesSkimmedPass1 </parameter>
+    
+    <!-- links between tracks or clusters and mcparticles. The two sets differ
+         in what the weight means. These four will only be output if the
+         name is given here in the steering -->
+    <parameter name="MCTruthTrackLinkName" type="string" lcioOutType="LCRelation"> MCTruthMarlinTrkTracksLinkPass1 </parameter>  
+    <parameter name="TrackMCTruthLinkName" type="string" lcioOutType="LCRelation"> MarlinTrkTracksMCTruthLinkPass1 </parameter>
+    <parameter name="MCTruthClusterLinkName" type="string" lcioOutType="LCRelation">  </parameter>
+    <parameter name="ClusterMCTruthLinkName" type="string" lcioOutType="LCRelation">  </parameter>
+
+
+    <!-- Links PFO <-> MCParticles. Only RecoMCTruthLink is output by default,
+         to also get the reverse link, MCTruthRecoLinkName must be given here -->
+    <parameter name="RecoMCTruthLinkName" type="string" lcioOutType="LCRelation">  </parameter>
+    <parameter name="MCTruthRecoLinkName" type="string" lcioOutType="LCRelation">  </parameter>
+    <!-- set to true to get the weights in RecoMCTruthLink to include both weights to
+         tracks and clusters. False implies that only the true particle that
+         gives most contributions to the track of the PFO (charged PFOs), or
+         to the cluster (neutral ones) is linked to the PFO -->
+    <parameter name="FullRecoRelation" type="bool"> true </parameter>
+    <!-- further options -->
+    <!--true: use relations for TrackerHits, false : use getRawHits -->
+    <parameter name="UseTrackerHitRelations" type="bool"> true </parameter>
+    <!--If Using Particle Gun Ignore Gen Stat-->
+    <parameter name="UsingParticleGun" type="bool"> false </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
+  </processor>
+
+
+
+
+  
+  <processor name="MyDDMarlinPandora" type="DDPandoraPFANewProcessor">
+    <!--Track cut on distance from BarrelTracker inner r to id whether track can form pfo-->
+    <parameter name="MaxBarrelTrackerInnerRDistance" type="float">105.0 </parameter>
+    <parameter name="PandoraSettingsXmlFile" type="String"> PandoraSettings/PandoraSettingsPerfectPFA.xml </parameter>
+    <parameter name="UseDD4hepField" type="bool">false</parameter>
+    <!-- Collection names -->
+    <parameter name="TrackCollections" type="StringVec">MarlinTrkTracks</parameter>
+    <parameter name="ECalCaloHitCollections" type="StringVec">EcalBarrelCollectionRec EcalBarrelCollectionGapHits EcalEndcapsCollectionRec EcalEndcapsCollectionGapHits EcalEndcapRingCollectionRec</parameter>
+    <parameter name="HCalCaloHitCollections" type="StringVec">HcalBarrelCollectionRec HcalEndcapsCollectionRec HcalEndcapRingCollectionRec</parameter>
+    <parameter name="LCalCaloHitCollections" type="StringVec">LCAL</parameter>
+    <parameter name="LHCalCaloHitCollections" type="StringVec">LHCAL</parameter>
+    <parameter name="MuonCaloHitCollections" type="StringVec">MUON</parameter>
+    <parameter name="MCParticleCollections" type="StringVec">MCParticle</parameter>
+    <parameter name="RelCaloHitCollections" type="StringVec">EcalBarrelRelationsSimRec EcalEndcapsRelationsSimRec EcalEndcapRingRelationsSimRec HcalBarrelRelationsSimRec HcalEndcapsRelationsSimRec HcalEndcapRingRelationsSimRec RelationMuonHit RelationLHcalHit RelationLcalHit</parameter>
+    <parameter name="RelTrackCollections" type="StringVec">MarlinTrkTracksMCTruthLinkPass1</parameter>
+    <parameter name="KinkVertexCollections" type="StringVec">KinkVertices</parameter>
+    <parameter name="ProngVertexCollections" type="StringVec">ProngVertices</parameter>
+    <parameter name="SplitVertexCollections" type="StringVec">SplitVertices</parameter>
+    <parameter name="V0VertexCollections" type="StringVec">V0Vertices</parameter>
+    <parameter name="StartVertexCollectionName" type="string">PandoraPFANewStartVertices</parameter>
+    <parameter name="StartVertexAlgorithmName" type="string">PandoraPFANew</parameter>
+    <parameter name="ClusterCollectionName" type="String">PandoraClusters</parameter>
+    <parameter name="PFOCollectionName" type="String">PandoraPFOs</parameter>
+    <!-- Calibration constants -->
+    <parameter name="ECalToMipCalibration">${PandoraEcalToMip}</parameter>
+    <parameter name="HCalToMipCalibration">${PandoraHcalToMip}</parameter>
+    <parameter name="MuonToMipCalibration">${PandoraMuonToMip}</parameter>
+    <parameter name="ECalMipThreshold" type="float">0.5</parameter>
+    <parameter name="HCalMipThreshold" type="float">0.3</parameter>
+    <parameter name="ECalToEMGeVCalibration">${PandoraEcalToEMScale}</parameter>
+    <parameter name="HCalToEMGeVCalibration">${PandoraHcalToEMScale}</parameter>
+    <parameter name="ECalToHadGeVCalibrationBarrel">${PandoraEcalToHadBarrelScale}</parameter>
+    <parameter name="ECalToHadGeVCalibrationEndCap">${PandoraEcalToHadEndcapScale}</parameter>
+    <parameter name="HCalToHadGeVCalibration">${PandoraHcalToHadScale}</parameter>
+    <parameter name="DigitalMuonHits" type="int">0</parameter>
+    <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.</parameter>
+    <parameter name="SoftwareCompensationWeights" type="FloatVec"> ${PandoraSoftwareCompensationWeights} </parameter>
+    <parameter name="SoftwareCompensationEnergyDensityBins" type="FloatVec">0  2  5  7.5  9.5  13  16  20  23.5  28</parameter>
+    <parameter name="FinalEnergyDensityBin" type="float">30</parameter>
+    <parameter name="MaxClusterEnergyToApplySoftComp" type="float">1000</parameter>
+    <parameter name="MinCleanHitEnergy" type="float">0.5</parameter>
+    <parameter name="MinCleanHitEnergyFraction" type="float">0.01</parameter>
+    <parameter name="MinCleanCorrectedHitEnergy" type="float">0.1</parameter>
+
+    <!--Whether to calculate track states manually, rather than copy stored fitter values-->
+    <parameter name="UseOldTrackStateCalculation" type="int"> 0 1  </parameter> <!-- !!!FIXME, workaround for some missing TS AtCalo face - this should really be: 0 -->
+    <parameter name="NEventsToSkip" type="int">0</parameter>
+    <!--parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG0 </parameter-->
+    <!--The name of the Vertex Barrel detector-->
+    <parameter name="VertexBarrelDetectorName" type="string">VXD </parameter>
+    <!--Detector names of the Trackers in the Barrel starting from the innermost one-->
+    <parameter name="TrackerBarrelDetectorNames" type="StringVec">TPC</parameter>
+    <!--Detector names of the Trackers in the Endcap starting from the innermost one-->
+    <parameter name="TrackerEndcapDetectorNames" type="StringVec">FTD</parameter>
+    <parameter name="CoilName" type="string">Coil</parameter>
+    <parameter name="ECalBarrelDetectorName" type="string">EcalBarrel </parameter>
+    <parameter name="ECalEndcapDetectorName" type="string">EcalEndcap </parameter>
+    <parameter name="ECalOtherDetectorNames" type="StringVec">EcalPlug Lcal BeamCal  </parameter>
+    <parameter name="HCalEndcapDetectorName" type="string">HcalEndcap </parameter>
+    <parameter name="HCalBarrelDetectorName" type="string">HcalBarrel </parameter>
+    <parameter name="HCalOtherDetectorNames" type="StringVec">HcalRing LHcal </parameter>
+    <parameter name="MuonBarrelDetectorName" type="string">YokeBarrel </parameter>
+    <parameter name="MuonEndcapDetectorName" type="string">YokeEndcap </parameter>
+    <parameter name="MuonOtherDetectorNames" type="StringVec"></parameter>
+    <!--Decides whether to create gaps in the geometry (ILD-specific)-->
+    <!---SHOULD BE TRUE FOR ILD BUT INNER/OUTER SYMMETRIES ARE NOT COMPATIBLE -->
+    <parameter name="CreateGaps" type="bool">false</parameter>
+
+    <!-- RE: Fix for driver Yoke05_Barrel in lcgeo. See PR #241 iLCSoft/lcgeo -->
+    <!-- The layers are oriented in (0,1,0) before placement in the stave/module -->
+    <parameter name="YokeBarrelNormalVector" type="FloatVec">0 1 0 </parameter>
+
+    <!--The name of the DDTrackCreator implementation-->
+    <parameter name="TrackCreatorName" type="string">DDTrackCreatorILD </parameter>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> SILENT </parameter>
+  </processor>
+
+</group>


### PR DESCRIPTION
This changes allows to run perfect PandoraPFA using MCtruth. To run perfectPFA, a relation between Tracks and true MCParticles has to be provided. This relation is produced by the RecoMCTruthLinker which is run after. 
When using perfectPFA, one needs the RecoMCTruthLinker to be run before Pandora for the track-truth association and after for the cluster-truth and reco-truth association.
 
BEGINRELEASENOTES
Add option to run different PFA type in Standard Reco and add an xml file to run perfect PandoraPFA based on MC truth.
ENDRELEASENOTES