### PR TITLE
Add CI workflows for running the 3 ttbar events tests

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -6,6 +6,10 @@ on:
     pull_request:
     workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   marlin-std-reco:
     runs-on: ubuntu-latest

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -69,7 +69,7 @@ jobs:
             echo "::group::Run simulation"
             cd StandardConfig/production
             ddsim --inputFiles Examples/bbudsc_3evt/bbudsc_3evt.stdhep \
-                  --outputFile bbudsc_3evt_SIM.edm4hep \
+                  --outputFile bbudsc_3evt_SIM.edm4hep.root \
                   --compactFile $lcgeo_DIR/ILD/compact/${{ matrix.detector_model }}/${{ matrix.detector_model }}.xml \
                   --steeringFile ddsim_steer.py
             echo "::endgroup::"

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,31 @@
+name: smoke-tests
+
+on:
+  push:
+    branches:
+    pull_request:
+    workflow_dispatch:
+
+jobs:
+  simulation:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        detector_model: [ILD_l5_o1_v02]
+        key4hep_build: [sw.hsf.org, sw-nightlies.hsf.org]
+        os: [ubuntu2204, el9]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cvmfs-contrib/github-action-cvmfs@v4
+      - uses: aidasoft/run-lcg-view@v4
+        with:
+          container: ${{ matrix.os }}
+          view-path: /cvmfs/${{ matrix.key4hep_build }}
+          run: |
+            cd StandardConfig/production
+            ddsim --inputFiles Examples/bbudsc_3evt/bbudsc_3evt.stdhep \
+                  --outputFile bbudsc_3evt_SIM.slcio \
+                  --compactFile $lcgeo_DIR/ILD/compact/${{ matrix.detector_model }}/${{ matrix.detector_model }}.xml \
+                  --steeringFile ddsim_steer.py

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -3,6 +3,7 @@ name: smoke-tests
 on:
   push:
     branches:
+      - master
     pull_request:
     workflow_dispatch:
 

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -53,6 +53,8 @@ jobs:
                    --constant.lcgeo_DIR=$lcgeo_DIR
             echo "::endgroup::"
 
+
+  # Reconstruction using EDM4hep inputs and outputs
   gaudi-std-reco:
     runs-on: ubuntu-latest
     strategy:
@@ -79,6 +81,6 @@ jobs:
             echo "::endgroup::"
             echo "::group::Run reconstruction"
             k4run ILDReconstruction.py \
-                  --inputFiles=bbudsc_3evt_SIM.edm4hep \
+                  --inputFiles=bbudsc_3evt_SIM.edm4hep.root \
                   --outputFileBase=bbudsc_3evt_GaudiRec \
-                  --detectorModel=${{ matrix.detectorModel }}
+                  --detectorModel=${{ matrix.detector_model }}

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -7,7 +7,49 @@ on:
     workflow_dispatch:
 
 jobs:
-  simulation:
+  marlin-std-reco:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        detector_model: [ILD_l5_o1_v02]
+        key4hep_build: [sw.hsf.org, sw-nightlies.hsf.org]
+        os: [ubuntu2204, el9]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cvmfs-contrib/github-action-cvmfs@v4
+      - uses: aidasoft/run-lcg-view@v4
+        with:
+          container: ${{ matrix.os }}
+          view-path: /cvmfs/${{ matrix.key4hep_build }}/key4hep
+          run: |
+            echo "::group::Run Simulation"
+            cd StandardConfig/production
+            ddsim --inputFiles Examples/bbudsc_3evt/bbudsc_3evt.stdhep \
+                  --outputFile bbudsc_3evt_SIM.slcio \
+                  --compactFile $lcgeo_DIR/ILD/compact/${{ matrix.detector_model }}/${{ matrix.detector_model }}.xml \
+                  --steeringFile ddsim_steer.py
+            echo "::endgroup::"
+            echo "::group::Run Reconstruction"
+            Marlin MarlinStdReco.xml \
+                   --constant.lcgeo_DIR=$lcgeo_DIR \
+                   --constant.DetectorModel=${{ matrix.detector_model }} \
+                   --constant.OutputBaseName=bbudsc_3evt \
+                   --global.LCIOInputFiles=bbudsc_3evt_SIM.slcio
+            echo "::endgroup::"
+            echo "::group::Run LCTuple"
+            Marlin MarlinStdRecoLCTuple.xml \
+                   --global.LCIOInputFiles=bbudsc_3evt_DST.slcio \
+                   --MyAIDAProcessor.FileName=bbudsc_3evt_LCTuple
+            echo "::endgroup::"
+            echo "::group::Run MiniDST production"
+            Marlin MarlinStdRecoMiniDST.xml \
+                   --global.LCIOInputFiles=bbudsc_3evt_DST.slcio \
+                   --constant.OutputFile=bbudsc_3evt_miniDST.slcio \
+                   --constant.lcgeo_DIR=$lcgeo_DIR
+            echo "::endgroup::"
+
+  gaudi-std-reco:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -22,10 +64,17 @@ jobs:
       - uses: aidasoft/run-lcg-view@v4
         with:
           container: ${{ matrix.os }}
-          view-path: /cvmfs/${{ matrix.key4hep_build }}
+          view-path: /cvmfs/${{ matrix.key4hep_build }}/key4hep
           run: |
+            echo "::group::Run simulation"
             cd StandardConfig/production
             ddsim --inputFiles Examples/bbudsc_3evt/bbudsc_3evt.stdhep \
-                  --outputFile bbudsc_3evt_SIM.slcio \
+                  --outputFile bbudsc_3evt_SIM.edm4hep \
                   --compactFile $lcgeo_DIR/ILD/compact/${{ matrix.detector_model }}/${{ matrix.detector_model }}.xml \
                   --steeringFile ddsim_steer.py
+            echo "::endgroup::"
+            echo "::group::Run reconstruction"
+            k4run ILDReconstruction.py \
+                  --inputFiles=bbudsc_3evt_SIM.edm4hep \
+                  --outputFileBase=bbudsc_3evt_GaudiRec \
+                  --detectorModel=${{ matrix.detectorModel }}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add CI workflows based on key4hep releases and nightlies that run the typical 3 ttbar events simulation & full reconstruction for
  - LCIO inputs / outputs using Marlin: `MarlinStdReco.xml`, `MarlinStdRecoLCTuple.xml` and `MarlinStdRecoMiniDST.xml`
  - EDM4hep inputs / outputs using Gaudi: `ILDReconstruction.py`
- The setup currently only uses the `ILD_l5_o1_v02` geometry, but more geometries can be added

ENDRELEASENOTES

Especially the Gaudi / MarlinWrapper based workflows are still a bit flaky because the event contents, including ParticleID meta information is not always the same so some randomness is in play and this still needs a bit more work to stabilize / homogenize the outputs better.