### PR TITLE
Remove all OutputLevel configurations from procesors

### DIFF
--- a/StandardConfig/production/BgOverlay/BgOverlay.py
+++ b/StandardConfig/production/BgOverlay/BgOverlay.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 BgOverlayWW = MarlinProcessorWrapper("BgOverlayWW")
-BgOverlayWW.OutputLevel = INFO
 BgOverlayWW.ProcessorType = "Overlay"
 BgOverlayWW.Parameters = {
     "InputFileNames": ["undefined.slcio"],
@@ -13,7 +11,6 @@ BgOverlayWW.Parameters = {
 }
 
 BgOverlayWB = MarlinProcessorWrapper("BgOverlayWB")
-BgOverlayWB.OutputLevel = INFO
 BgOverlayWB.ProcessorType = "Overlay"
 BgOverlayWB.Parameters = {
     "InputFileNames": ["undefined.slcio"],
@@ -22,7 +19,6 @@ BgOverlayWB.Parameters = {
 }
 
 BgOverlayBW = MarlinProcessorWrapper("BgOverlayBW")
-BgOverlayBW.OutputLevel = INFO
 BgOverlayBW.ProcessorType = "Overlay"
 BgOverlayBW.Parameters = {
     "InputFileNames": ["undefined.slcio"],
@@ -31,7 +27,6 @@ BgOverlayBW.Parameters = {
 }
 
 BgOverlayBB = MarlinProcessorWrapper("BgOverlayBB")
-BgOverlayBB.OutputLevel = INFO
 BgOverlayBB.ProcessorType = "Overlay"
 BgOverlayBB.Parameters = {
     "InputFileNames": ["undefined.slcio"],
@@ -40,7 +35,6 @@ BgOverlayBB.Parameters = {
 }
 
 PairBgOverlay = MarlinProcessorWrapper("PairBgOverlay")
-PairBgOverlay.OutputLevel = INFO
 PairBgOverlay.ProcessorType = "Overlay"
 PairBgOverlay.Parameters = {
     "ExcludeCollections": ["BeamCalCollection"],

--- a/StandardConfig/production/CaloDigi/AHcalDigi.py
+++ b/StandardConfig/production/CaloDigi/AHcalDigi.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MyHcalBarrelDigi = MarlinProcessorWrapper("MyHcalBarrelDigi")
-MyHcalBarrelDigi.OutputLevel = INFO
 MyHcalBarrelDigi.ProcessorType = "RealisticCaloDigiScinPpd"
 MyHcalBarrelDigi.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -22,7 +20,6 @@ MyHcalBarrelDigi.Parameters = {
 }
 
 MyHcalBarrelReco = MarlinProcessorWrapper("MyHcalBarrelReco")
-MyHcalBarrelReco.OutputLevel = INFO
 MyHcalBarrelReco.ProcessorType = "RealisticCaloRecoScinPpd"
 MyHcalBarrelReco.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -37,7 +34,6 @@ MyHcalBarrelReco.Parameters = {
 }
 
 MyHcalEndcapDigi = MarlinProcessorWrapper("MyHcalEndcapDigi")
-MyHcalEndcapDigi.OutputLevel = INFO
 MyHcalEndcapDigi.ProcessorType = "RealisticCaloDigiScinPpd"
 MyHcalEndcapDigi.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -55,7 +51,6 @@ MyHcalEndcapDigi.Parameters = {
 }
 
 MyHcalEndcapReco = MarlinProcessorWrapper("MyHcalEndcapReco")
-MyHcalEndcapReco.OutputLevel = INFO
 MyHcalEndcapReco.ProcessorType = "RealisticCaloRecoScinPpd"
 MyHcalEndcapReco.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -70,7 +65,6 @@ MyHcalEndcapReco.Parameters = {
 }
 
 MyHcalRingDigi = MarlinProcessorWrapper("MyHcalRingDigi")
-MyHcalRingDigi.OutputLevel = INFO
 MyHcalRingDigi.ProcessorType = "RealisticCaloDigiScinPpd"
 MyHcalRingDigi.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -88,7 +82,6 @@ MyHcalRingDigi.Parameters = {
 }
 
 MyHcalRingReco = MarlinProcessorWrapper("MyHcalRingReco")
-MyHcalRingReco.OutputLevel = INFO
 MyHcalRingReco.ProcessorType = "RealisticCaloRecoScinPpd"
 MyHcalRingReco.Parameters = {
     "CellIDLayerString": ["layer"],

--- a/StandardConfig/production/CaloDigi/FcalDigi.py
+++ b/StandardConfig/production/CaloDigi/FcalDigi.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 
 MySimpleBCalDigi = MarlinProcessorWrapper("MySimpleBCalDigi")
-MySimpleBCalDigi.OutputLevel = INFO
 MySimpleBCalDigi.ProcessorType = "SimpleFCalDigi"
 MySimpleBCalDigi.Parameters = {
     "CalibrFCAL": [CONSTANTS["BeamCalCalibrationFactor"]],
@@ -18,7 +16,6 @@ MySimpleBCalDigi.Parameters = {
 }
 
 MySimpleLCalDigi = MarlinProcessorWrapper("MySimpleLCalDigi")
-MySimpleLCalDigi.OutputLevel = INFO
 MySimpleLCalDigi.ProcessorType = "SimpleFCalDigi"
 MySimpleLCalDigi.Parameters = {
     "CalibrFCAL": ["89.0"],
@@ -31,7 +28,6 @@ MySimpleLCalDigi.Parameters = {
 }
 
 MySimpleLHCalDigi = MarlinProcessorWrapper("MySimpleLHCalDigi")
-MySimpleLHCalDigi.OutputLevel = INFO
 MySimpleLHCalDigi.ProcessorType = "SimpleFCalDigi"
 MySimpleLHCalDigi.Parameters = {
     "CalibrFCAL": ["150"],

--- a/StandardConfig/production/CaloDigi/MuonDigi.py
+++ b/StandardConfig/production/CaloDigi/MuonDigi.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MyDDSimpleMuonDigi = MarlinProcessorWrapper("MyDDSimpleMuonDigi")
-MyDDSimpleMuonDigi.OutputLevel = INFO
 MyDDSimpleMuonDigi.ProcessorType = "DDSimpleMuonDigi"
 MyDDSimpleMuonDigi.Parameters = {
     "CalibrMUON": [CONSTANTS["MuonCalibration"]],

--- a/StandardConfig/production/CaloDigi/SDHcalDigi.py
+++ b/StandardConfig/production/CaloDigi/SDHcalDigi.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MySimDigital = MarlinProcessorWrapper("MySimDigital")
-MySimDigital.OutputLevel = INFO
 MySimDigital.ProcessorType = "SimDigital"
 MySimDigital.Parameters = {
     "AngleCorrectionPower": ["0.65"],
@@ -42,7 +40,6 @@ MySimDigital.Parameters = {
 }
 
 MySimDigitalToEnergy = MarlinProcessorWrapper("MySimDigitalToEnergy")
-MySimDigitalToEnergy.OutputLevel = INFO
 MySimDigitalToEnergy.ProcessorType = "SimDigitalToEnergy"
 MySimDigitalToEnergy.Parameters = {
     "EnergyCalibration": [CONSTANTS["SDHcalEnergyFactors"]],

--- a/StandardConfig/production/CaloDigi/ScEcalDigi.py
+++ b/StandardConfig/production/CaloDigi/ScEcalDigi.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MyEcalBarrelDigiEven = MarlinProcessorWrapper("MyEcalBarrelDigiEven")
-MyEcalBarrelDigiEven.OutputLevel = INFO
 MyEcalBarrelDigiEven.ProcessorType = "RealisticCaloDigiScinPpd"
 MyEcalBarrelDigiEven.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -22,7 +20,6 @@ MyEcalBarrelDigiEven.Parameters = {
 }
 
 MyEcalBarrelDigiOdd = MarlinProcessorWrapper("MyEcalBarrelDigiOdd")
-MyEcalBarrelDigiOdd.OutputLevel = INFO
 MyEcalBarrelDigiOdd.ProcessorType = "RealisticCaloDigiScinPpd"
 MyEcalBarrelDigiOdd.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -40,7 +37,6 @@ MyEcalBarrelDigiOdd.Parameters = {
 }
 
 MyEcalBarrelRecoEven = MarlinProcessorWrapper("MyEcalBarrelRecoEven")
-MyEcalBarrelRecoEven.OutputLevel = INFO
 MyEcalBarrelRecoEven.ProcessorType = "RealisticCaloRecoScinPpd"
 MyEcalBarrelRecoEven.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -55,7 +51,6 @@ MyEcalBarrelRecoEven.Parameters = {
 }
 
 MyEcalBarrelRecoOdd = MarlinProcessorWrapper("MyEcalBarrelRecoOdd")
-MyEcalBarrelRecoOdd.OutputLevel = INFO
 MyEcalBarrelRecoOdd.ProcessorType = "RealisticCaloRecoScinPpd"
 MyEcalBarrelRecoOdd.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -70,7 +65,6 @@ MyEcalBarrelRecoOdd.Parameters = {
 }
 
 MyEcalEndcapDigiEven = MarlinProcessorWrapper("MyEcalEndcapDigiEven")
-MyEcalEndcapDigiEven.OutputLevel = INFO
 MyEcalEndcapDigiEven.ProcessorType = "RealisticCaloDigiScinPpd"
 MyEcalEndcapDigiEven.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -88,7 +82,6 @@ MyEcalEndcapDigiEven.Parameters = {
 }
 
 MyEcalEndcapDigiOdd = MarlinProcessorWrapper("MyEcalEndcapDigiOdd")
-MyEcalEndcapDigiOdd.OutputLevel = INFO
 MyEcalEndcapDigiOdd.ProcessorType = "RealisticCaloDigiScinPpd"
 MyEcalEndcapDigiOdd.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -106,7 +99,6 @@ MyEcalEndcapDigiOdd.Parameters = {
 }
 
 MyEcalEndcapRecoEven = MarlinProcessorWrapper("MyEcalEndcapRecoEven")
-MyEcalEndcapRecoEven.OutputLevel = INFO
 MyEcalEndcapRecoEven.ProcessorType = "RealisticCaloRecoScinPpd"
 MyEcalEndcapRecoEven.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -121,7 +113,6 @@ MyEcalEndcapRecoEven.Parameters = {
 }
 
 MyEcalEndcapRecoOdd = MarlinProcessorWrapper("MyEcalEndcapRecoOdd")
-MyEcalEndcapRecoOdd.OutputLevel = INFO
 MyEcalEndcapRecoOdd.ProcessorType = "RealisticCaloRecoScinPpd"
 MyEcalEndcapRecoOdd.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -136,7 +127,6 @@ MyEcalEndcapRecoOdd.Parameters = {
 }
 
 MyEcalRingDigi = MarlinProcessorWrapper("MyEcalRingDigi")
-MyEcalRingDigi.OutputLevel = INFO
 MyEcalRingDigi.ProcessorType = "RealisticCaloDigiSilicon"
 MyEcalRingDigi.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -149,7 +139,6 @@ MyEcalRingDigi.Parameters = {
 }
 
 MyEcalRingReco = MarlinProcessorWrapper("MyEcalRingReco")
-MyEcalRingReco.OutputLevel = INFO
 MyEcalRingReco.ProcessorType = "RealisticCaloRecoSilicon"
 MyEcalRingReco.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -162,7 +151,6 @@ MyEcalRingReco.Parameters = {
 }
 
 MyDDStripSplitterBarrel = MarlinProcessorWrapper("MyDDStripSplitterBarrel")
-MyDDStripSplitterBarrel.OutputLevel = INFO
 MyDDStripSplitterBarrel.ProcessorType = "DDStripSplitter"
 MyDDStripSplitterBarrel.Parameters = {
     "ECALcollection_evenLayers": ["ECalBarrelScHitsEvenRec"],
@@ -176,7 +164,6 @@ MyDDStripSplitterBarrel.Parameters = {
 }
 
 MyDDStripSplitterEndcap = MarlinProcessorWrapper("MyDDStripSplitterEndcap")
-MyDDStripSplitterEndcap.OutputLevel = INFO
 MyDDStripSplitterEndcap.ProcessorType = "DDStripSplitter"
 MyDDStripSplitterEndcap.Parameters = {
     "ECALcollection_evenLayers": ["ECalEndcapScHitsEvenRec"],
@@ -190,7 +177,6 @@ MyDDStripSplitterEndcap.Parameters = {
 }
 
 MergeEcalBarrelHits = MarlinProcessorWrapper("MergeEcalBarrelHits")
-MergeEcalBarrelHits.OutputLevel = INFO
 MergeEcalBarrelHits.ProcessorType = "MergeCollections"
 MergeEcalBarrelHits.Parameters = {
     "InputCollections": ["ECalBarrelScHitsEven", "ECalBarrelScHitsOdd"],
@@ -198,7 +184,6 @@ MergeEcalBarrelHits.Parameters = {
 }
 
 MergeEcalEndcapHits = MarlinProcessorWrapper("MergeEcalEndcapHits")
-MergeEcalEndcapHits.OutputLevel = INFO
 MergeEcalEndcapHits.ProcessorType = "MergeCollections"
 MergeEcalEndcapHits.Parameters = {
     "InputCollections": ["ECalEndcapScHitsEven", "ECalEndcapScHitsOdd"],
@@ -206,7 +191,6 @@ MergeEcalEndcapHits.Parameters = {
 }
 
 MergeEcalBarrelDigiHits = MarlinProcessorWrapper("MergeEcalBarrelDigiHits")
-MergeEcalBarrelDigiHits.OutputLevel = INFO
 MergeEcalBarrelDigiHits.ProcessorType = "MergeCollections"
 MergeEcalBarrelDigiHits.Parameters = {
     "InputCollections": ["ECalBarrelScHitsEvenDigi", "ECalBarrelScHitsOddDigi"],
@@ -214,7 +198,6 @@ MergeEcalBarrelDigiHits.Parameters = {
 }
 
 MergeEcalEndcapDigiHits = MarlinProcessorWrapper("MergeEcalEndcapDigiHits")
-MergeEcalEndcapDigiHits.OutputLevel = INFO
 MergeEcalEndcapDigiHits.ProcessorType = "MergeCollections"
 MergeEcalEndcapDigiHits.Parameters = {
     "InputCollections": ["ECalEndcapScHitsEvenDigi", "ECalEndcapScHitsOddDigi"],
@@ -222,7 +205,6 @@ MergeEcalEndcapDigiHits.Parameters = {
 }
 
 MergeEcalBarrelRecStripHits = MarlinProcessorWrapper("MergeEcalBarrelRecStripHits")
-MergeEcalBarrelRecStripHits.OutputLevel = INFO
 MergeEcalBarrelRecStripHits.ProcessorType = "MergeCollections"
 MergeEcalBarrelRecStripHits.Parameters = {
     "InputCollections": ["ECalBarrelScHitsEvenRec", "ECalBarrelScHitsOddRec"],
@@ -230,7 +212,6 @@ MergeEcalBarrelRecStripHits.Parameters = {
 }
 
 MergeEcalEndcapRecStripHits = MarlinProcessorWrapper("MergeEcalEndcapRecStripHits")
-MergeEcalEndcapRecStripHits.OutputLevel = INFO
 MergeEcalEndcapRecStripHits.ProcessorType = "MergeCollections"
 MergeEcalEndcapRecStripHits.Parameters = {
     "InputCollections": ["ECalEndcapScHitsEvenRec", "ECalEndcapScHitsOddRec"],
@@ -238,7 +219,6 @@ MergeEcalEndcapRecStripHits.Parameters = {
 }
 
 MergeEcalBarrelRecHits = MarlinProcessorWrapper("MergeEcalBarrelRecHits")
-MergeEcalBarrelRecHits.OutputLevel = INFO
 MergeEcalBarrelRecHits.ProcessorType = "MergeCollections"
 MergeEcalBarrelRecHits.Parameters = {
     "InputCollections": ["ECalBarrelScHitsSplit", "ECalBarrelScHitsUnSplit"],
@@ -246,7 +226,6 @@ MergeEcalBarrelRecHits.Parameters = {
 }
 
 MergeEcalEndcapRecHits = MarlinProcessorWrapper("MergeEcalEndcapRecHits")
-MergeEcalEndcapRecHits.OutputLevel = INFO
 MergeEcalEndcapRecHits.ProcessorType = "MergeCollections"
 MergeEcalEndcapRecHits.Parameters = {
     "InputCollections": ["ECalEndcapScHitsSplit", "ECalEndcapScHitsUnSplit"],

--- a/StandardConfig/production/CaloDigi/SiWEcalDigi.py
+++ b/StandardConfig/production/CaloDigi/SiWEcalDigi.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MergeCollectionsEcalBarrelHits = MarlinProcessorWrapper(
     "MergeCollectionsEcalBarrelHits"
 )
-MergeCollectionsEcalBarrelHits.OutputLevel = INFO
 MergeCollectionsEcalBarrelHits.ProcessorType = "MergeCollections"
 MergeCollectionsEcalBarrelHits.Parameters = {
     "InputCollections": ["ECalBarrelSiHitsEven", "ECalBarrelSiHitsOdd"],
@@ -16,7 +14,6 @@ MergeCollectionsEcalBarrelHits.Parameters = {
 MergeCollectionsEcalEndcapHits = MarlinProcessorWrapper(
     "MergeCollectionsEcalEndcapHits"
 )
-MergeCollectionsEcalEndcapHits.OutputLevel = INFO
 MergeCollectionsEcalEndcapHits.ProcessorType = "MergeCollections"
 MergeCollectionsEcalEndcapHits.Parameters = {
     "InputCollections": ["ECalEndcapSiHitsEven", "ECalEndcapSiHitsOdd"],
@@ -24,7 +21,6 @@ MergeCollectionsEcalEndcapHits.Parameters = {
 }
 
 MyEcalBarrelDigi = MarlinProcessorWrapper("MyEcalBarrelDigi")
-MyEcalBarrelDigi.OutputLevel = INFO
 MyEcalBarrelDigi.ProcessorType = "RealisticCaloDigiSilicon"
 MyEcalBarrelDigi.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -37,7 +33,6 @@ MyEcalBarrelDigi.Parameters = {
 }
 
 MyEcalBarrelReco = MarlinProcessorWrapper("MyEcalBarrelReco")
-MyEcalBarrelReco.OutputLevel = INFO
 MyEcalBarrelReco.ProcessorType = "RealisticCaloRecoSilicon"
 MyEcalBarrelReco.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -50,7 +45,6 @@ MyEcalBarrelReco.Parameters = {
 }
 
 MyEcalBarrelGapFiller = MarlinProcessorWrapper("MyEcalBarrelGapFiller")
-MyEcalBarrelGapFiller.OutputLevel = INFO
 MyEcalBarrelGapFiller.ProcessorType = "BruteForceEcalGapFiller"
 MyEcalBarrelGapFiller.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -63,7 +57,6 @@ MyEcalBarrelGapFiller.Parameters = {
 }
 
 MyEcalEndcapDigi = MarlinProcessorWrapper("MyEcalEndcapDigi")
-MyEcalEndcapDigi.OutputLevel = INFO
 MyEcalEndcapDigi.ProcessorType = "RealisticCaloDigiSilicon"
 MyEcalEndcapDigi.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -76,7 +69,6 @@ MyEcalEndcapDigi.Parameters = {
 }
 
 MyEcalEndcapReco = MarlinProcessorWrapper("MyEcalEndcapReco")
-MyEcalEndcapReco.OutputLevel = INFO
 MyEcalEndcapReco.ProcessorType = "RealisticCaloRecoSilicon"
 MyEcalEndcapReco.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -89,7 +81,6 @@ MyEcalEndcapReco.Parameters = {
 }
 
 MyEcalEndcapGapFiller = MarlinProcessorWrapper("MyEcalEndcapGapFiller")
-MyEcalEndcapGapFiller.OutputLevel = INFO
 MyEcalEndcapGapFiller.ProcessorType = "BruteForceEcalGapFiller"
 MyEcalEndcapGapFiller.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -102,7 +93,6 @@ MyEcalEndcapGapFiller.Parameters = {
 }
 
 MyEcalRingDigi = MarlinProcessorWrapper("MyEcalRingDigi")
-MyEcalRingDigi.OutputLevel = INFO
 MyEcalRingDigi.ProcessorType = "RealisticCaloDigiSilicon"
 MyEcalRingDigi.Parameters = {
     "CellIDLayerString": ["layer"],
@@ -115,7 +105,6 @@ MyEcalRingDigi.Parameters = {
 }
 
 MyEcalRingReco = MarlinProcessorWrapper("MyEcalRingReco")
-MyEcalRingReco.OutputLevel = INFO
 MyEcalRingReco.ProcessorType = "RealisticCaloRecoSilicon"
 MyEcalRingReco.Parameters = {
     "CellIDLayerString": ["layer"],

--- a/StandardConfig/production/HighLevelReco/BeamCalReco.py
+++ b/StandardConfig/production/HighLevelReco/BeamCalReco.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MyBeamCalClusterReco = MarlinProcessorWrapper("MyBeamCalClusterReco")
-MyBeamCalClusterReco.OutputLevel = INFO
 MyBeamCalClusterReco.ProcessorType = "BeamCalClusterReco"
 MyBeamCalClusterReco.Parameters = {
     "BackgroundMethod": ["Gaussian"],

--- a/StandardConfig/production/HighLevelReco/HighLevelReco.py
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 
 from Configurables import MarlinProcessorWrapper
-from Gaudi.Configuration import INFO
 
 MyAdd4MomCovMatrixCharged = MarlinProcessorWrapper("MyAdd4MomCovMatrixCharged")
-MyAdd4MomCovMatrixCharged.OutputLevel = INFO
 MyAdd4MomCovMatrixCharged.ProcessorType = "Add4MomCovMatrixCharged"
 MyAdd4MomCovMatrixCharged.Parameters = {"InputPandoraPFOsCollection": ["PandoraPFOs"]}
 
 MyAddClusterProperties = MarlinProcessorWrapper("MyAddClusterProperties")
-MyAddClusterProperties.OutputLevel = INFO
 MyAddClusterProperties.ProcessorType = "AddClusterProperties"
 MyAddClusterProperties.Parameters = {
     "ClusterCollection": ["PandoraClusters"],
@@ -19,7 +16,6 @@ MyAddClusterProperties.Parameters = {
 MyComputeShowerShapesProcessor = MarlinProcessorWrapper(
     "MyComputeShowerShapesProcessor"
 )
-MyComputeShowerShapesProcessor.OutputLevel = INFO
 MyComputeShowerShapesProcessor.ProcessorType = "ComputeShowerShapesProcessor"
 MyComputeShowerShapesProcessor.Parameters = {
     "ClusterCollectionName": ["PandoraClusters"],
@@ -32,7 +28,6 @@ MyComputeShowerShapesProcessor.Parameters = {
 }
 
 MyphotonCorrectionProcessor = MarlinProcessorWrapper("MyphotonCorrectionProcessor")
-MyphotonCorrectionProcessor.OutputLevel = INFO
 MyphotonCorrectionProcessor.ProcessorType = "photonCorrectionProcessor"
 MyphotonCorrectionProcessor.Parameters = {
     "energyCor_Linearise": ["0.987", "0.01426"],
@@ -95,7 +90,6 @@ MyphotonCorrectionProcessor.Parameters = {
 }
 
 MyPi0Finder = MarlinProcessorWrapper("MyPi0Finder")
-MyPi0Finder.OutputLevel = INFO
 MyPi0Finder.ProcessorType = "GammaGammaCandidateFinder"
 MyPi0Finder.Parameters = {
     "GammaGammaResonanceMass": ["0.1349766"],
@@ -108,7 +102,6 @@ MyPi0Finder.Parameters = {
 }
 
 MyEtaFinder = MarlinProcessorWrapper("MyEtaFinder")
-MyEtaFinder.OutputLevel = INFO
 MyEtaFinder.ProcessorType = "GammaGammaCandidateFinder"
 MyEtaFinder.Parameters = {
     "GammaGammaResonanceMass": ["0.547862"],
@@ -121,7 +114,6 @@ MyEtaFinder.Parameters = {
 }
 
 MyEtaPrimeFinder = MarlinProcessorWrapper("MyEtaPrimeFinder")
-MyEtaPrimeFinder.OutputLevel = INFO
 MyEtaPrimeFinder.ProcessorType = "GammaGammaCandidateFinder"
 MyEtaPrimeFinder.Parameters = {
     "GammaGammaResonanceMass": ["0.95778"],
@@ -134,7 +126,6 @@ MyEtaPrimeFinder.Parameters = {
 }
 
 MyGammaGammaSolutionFinder = MarlinProcessorWrapper("MyGammaGammaSolutionFinder")
-MyGammaGammaSolutionFinder.OutputLevel = INFO
 MyGammaGammaSolutionFinder.ProcessorType = "GammaGammaSolutionFinder"
 MyGammaGammaSolutionFinder.Parameters = {
     "InputParticleCollectionName1": ["GammaGammaCandidatePi0s"],
@@ -145,7 +136,6 @@ MyGammaGammaSolutionFinder.Parameters = {
 }
 
 MyDistilledPFOCreator = MarlinProcessorWrapper("MyDistilledPFOCreator")
-MyDistilledPFOCreator.OutputLevel = INFO
 MyDistilledPFOCreator.ProcessorType = "DistilledPFOCreator"
 MyDistilledPFOCreator.Parameters = {
     "InputParticleCollectionName1": ["PandoraPFOs"],
@@ -155,7 +145,6 @@ MyDistilledPFOCreator.Parameters = {
 }
 
 MyLikelihoodPID = MarlinProcessorWrapper("MyLikelihoodPID")
-MyLikelihoodPID.OutputLevel = INFO
 MyLikelihoodPID.ProcessorType = "LikelihoodPIDProcessor"
 MyLikelihoodPID.Parameters = {
     # fmt: off
@@ -214,7 +203,6 @@ MyLikelihoodPID.Parameters = {
 }
 
 MyRecoMCTruthLinker = MarlinProcessorWrapper("MyRecoMCTruthLinker")
-MyRecoMCTruthLinker.OutputLevel = INFO
 MyRecoMCTruthLinker.ProcessorType = "RecoMCTruthLinker"
 MyRecoMCTruthLinker.Parameters = {
     "ClusterCollection": ["PandoraClusters"],
@@ -272,7 +260,6 @@ MyRecoMCTruthLinker.Parameters = {
 }
 
 VertexFinder = MarlinProcessorWrapper("VertexFinder")
-VertexFinder.OutputLevel = INFO
 VertexFinder.ProcessorType = "LcfiplusProcessor"
 VertexFinder.Parameters = {
     "Algorithms": ["PrimaryVertexFinder", "BuildUpVertex"],
@@ -317,12 +304,10 @@ VertexFinder.Parameters = {
 }
 
 TrackLengthProcessor = MarlinProcessorWrapper("TrackLengthProcessor")
-TrackLengthProcessor.OutputLevel = INFO
 TrackLengthProcessor.ProcessorType = "TrackLengthProcessor"
 TrackLengthProcessor.Parameters = {"ReconstructedParticleCollection": ["PandoraPFOs"]}
 
 TOFEstimators0ps = MarlinProcessorWrapper("TOFEstimators0ps")
-TOFEstimators0ps.OutputLevel = INFO
 TOFEstimators0ps.ProcessorType = "TOFEstimators"
 TOFEstimators0ps.Parameters = {
     "ExtrapolateToEcal": ["true"],
@@ -333,7 +318,6 @@ TOFEstimators0ps.Parameters = {
 }
 
 TOFEstimators10ps = MarlinProcessorWrapper("TOFEstimators10ps")
-TOFEstimators10ps.OutputLevel = INFO
 TOFEstimators10ps.ProcessorType = "TOFEstimators"
 TOFEstimators10ps.Parameters = {
     "ExtrapolateToEcal": ["true"],
@@ -344,7 +328,6 @@ TOFEstimators10ps.Parameters = {
 }
 
 TOFEstimators50ps = MarlinProcessorWrapper("TOFEstimators50ps")
-TOFEstimators50ps.OutputLevel = INFO
 TOFEstimators50ps.ProcessorType = "TOFEstimators"
 TOFEstimators50ps.Parameters = {
     "ExtrapolateToEcal": ["true"],
@@ -355,7 +338,6 @@ TOFEstimators50ps.Parameters = {
 }
 
 TOFEstimators100ps = MarlinProcessorWrapper("TOFEstimators100ps")
-TOFEstimators100ps.OutputLevel = INFO
 TOFEstimators100ps.ProcessorType = "TOFEstimators"
 TOFEstimators100ps.Parameters = {
     "ExtrapolateToEcal": ["true"],

--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -205,7 +205,6 @@ else:
 
 
 MyAIDAProcessor = MarlinProcessorWrapper("MyAIDAProcessor")
-MyAIDAProcessor.OutputLevel = INFO
 MyAIDAProcessor.ProcessorType = "AIDAProcessor"
 MyAIDAProcessor.Parameters = {
     "Compress": ["1"],
@@ -224,7 +223,6 @@ if isinstance(read, PodioInput):
 
 
 MyStatusmonitor = MarlinProcessorWrapper("MyStatusmonitor")
-MyStatusmonitor.OutputLevel = INFO
 MyStatusmonitor.ProcessorType = "Statusmonitor"
 MyStatusmonitor.Parameters = {"HowOften": ["1"]}
 algList.append(MyStatusmonitor)
@@ -269,7 +267,6 @@ if not reco_args.trackingOnly:
 
 
 MyPfoAnalysis = MarlinProcessorWrapper("MyPfoAnalysis")
-MyPfoAnalysis.OutputLevel = INFO
 MyPfoAnalysis.ProcessorType = "PfoAnalysis"
 MyPfoAnalysis.Parameters = {
     "BCalCollections": ["BCAL"],
@@ -317,12 +314,11 @@ if reco_args.lcioOutput != "only":
     lcioToEDM4hepOutput = Lcio2EDM4hepTool("OutputConversion")
     # Take care of the different naming conventions
     lcioToEDM4hepOutput.collNameMapping = {"MCParticle": "MCParticles"}
-    lcioToEDM4hepOutput.OutputLevel = INFO
 
     # Make sure that all collections are always available by patching in missing
     # ones on-the-fly
     collPatcherRec = MarlinProcessorWrapper(
-        "CollPacherREC", OutputLevel=INFO, ProcessorType="PatchCollections"
+        "CollPacherREC", ProcessorType="PatchCollections"
     )
     collPatcherRec.Parameters = {
         "PatchCollections": parse_collection_patch_file(REC_COLLECTION_CONTENTS_FILE)
@@ -341,7 +337,6 @@ if reco_args.lcioOutput != "only":
 
 if reco_args.lcioOutput in ("on", "only"):
     MyLCIOOutputProcessor = MarlinProcessorWrapper("MyLCIOOutputProcessor")
-    MyLCIOOutputProcessor.OutputLevel = INFO
     MyLCIOOutputProcessor.ProcessorType = "LCIOOutputProcessor"
     MyLCIOOutputProcessor.Parameters = {
         "CompressionLevel": ["6"],
@@ -351,7 +346,6 @@ if reco_args.lcioOutput in ("on", "only"):
     }
 
     DSTOutput = MarlinProcessorWrapper("DSTOutput")
-    DSTOutput.OutputLevel = INFO
     DSTOutput.ProcessorType = "LCIOOutputProcessor"
     DSTOutput.Parameters = {
         "CompressionLevel": ["6"],

--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -112,7 +112,7 @@
     <parameter name="MaxRecordNumber" value="0"/>
     <parameter name="SkipNEvents" value="0"/>
     <parameter name="SupressCheck" value="false"/>
-    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG </parameter>
     <parameter name="RandomSeed" value="1234567890" />
     <parameter name="OutputSteeringFile" value="MarlinStdRecoParsed.xml"/>
   </global>

--- a/StandardConfig/production/ParticleFlow/PandoraPFA.py
+++ b/StandardConfig/production/ParticleFlow/PandoraPFA.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MyDDMarlinPandora = MarlinProcessorWrapper("MyDDMarlinPandora")
-MyDDMarlinPandora.OutputLevel = INFO
 MyDDMarlinPandora.ProcessorType = "DDPandoraPFANewProcessor"
 MyDDMarlinPandora.Parameters = {
     "ClusterCollectionName": ["PandoraClusters"],

--- a/StandardConfig/production/ParticleFlow/PandoraPFAPerfect.py
+++ b/StandardConfig/production/ParticleFlow/PandoraPFAPerfect.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MyRecoMCTruthLinkerPass1 = MarlinProcessorWrapper("MyRecoMCTruthLinkerPass1")
-MyRecoMCTruthLinkerPass1.OutputLevel = INFO
 MyRecoMCTruthLinkerPass1.ProcessorType = "RecoMCTruthLinker"
 MyRecoMCTruthLinkerPass1.Parameters = {
     "ClusterCollection": [],
@@ -43,7 +41,6 @@ MyRecoMCTruthLinkerPass1.Parameters = {
 }
 
 MyDDMarlinPandora = MarlinProcessorWrapper("MyDDMarlinPandora")
-MyDDMarlinPandora.OutputLevel = INFO
 MyDDMarlinPandora.ProcessorType = "DDPandoraPFANewProcessor"
 MyDDMarlinPandora.Parameters = {
     "ClusterCollectionName": ["PandoraClusters"],

--- a/StandardConfig/production/Tracking/TrackingDigi.py
+++ b/StandardConfig/production/Tracking/TrackingDigi.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
 from Configurables import MarlinProcessorWrapper
-from Gaudi.Configuration import INFO
 
 MySplitCollectionByLayer = MarlinProcessorWrapper("MySplitCollectionByLayer")
-MySplitCollectionByLayer.OutputLevel = INFO
 MySplitCollectionByLayer.ProcessorType = "SplitCollectionByLayer"
 MySplitCollectionByLayer.Parameters = {
     "InputCollection": ["FTDCollection"],
@@ -21,7 +19,6 @@ MySplitCollectionByLayer.Parameters = {
 VXDPlanarDigiProcessor_CMOSVXD5 = MarlinProcessorWrapper(
     "VXDPlanarDigiProcessor_CMOSVXD5"
 )
-VXDPlanarDigiProcessor_CMOSVXD5.OutputLevel = INFO
 VXDPlanarDigiProcessor_CMOSVXD5.ProcessorType = "DDPlanarDigiProcessor"
 VXDPlanarDigiProcessor_CMOSVXD5.Parameters = {
     "ForceHitsOntoSurface": ["true"],
@@ -35,7 +32,6 @@ VXDPlanarDigiProcessor_CMOSVXD5.Parameters = {
 }
 
 SITPlanarDigiProcessor = MarlinProcessorWrapper("SITPlanarDigiProcessor")
-SITPlanarDigiProcessor.OutputLevel = INFO
 SITPlanarDigiProcessor.ProcessorType = "DDPlanarDigiProcessor"
 SITPlanarDigiProcessor.Parameters = {
     "ForceHitsOntoSurface": ["true"],
@@ -49,7 +45,6 @@ SITPlanarDigiProcessor.Parameters = {
 }
 
 FTDPixelPlanarDigiProcessor = MarlinProcessorWrapper("FTDPixelPlanarDigiProcessor")
-FTDPixelPlanarDigiProcessor.OutputLevel = INFO
 FTDPixelPlanarDigiProcessor.ProcessorType = "DDPlanarDigiProcessor"
 FTDPixelPlanarDigiProcessor.Parameters = {
     "ForceHitsOntoSurface": ["true"],
@@ -63,7 +58,6 @@ FTDPixelPlanarDigiProcessor.Parameters = {
 }
 
 FTDStripPlanarDigiProcessor = MarlinProcessorWrapper("FTDStripPlanarDigiProcessor")
-FTDStripPlanarDigiProcessor.OutputLevel = INFO
 FTDStripPlanarDigiProcessor.ProcessorType = "DDPlanarDigiProcessor"
 FTDStripPlanarDigiProcessor.Parameters = {
     "ForceHitsOntoSurface": ["true"],
@@ -77,7 +71,6 @@ FTDStripPlanarDigiProcessor.Parameters = {
 }
 
 FTDDDSpacePointBuilder = MarlinProcessorWrapper("FTDDDSpacePointBuilder")
-FTDDDSpacePointBuilder.OutputLevel = INFO
 FTDDDSpacePointBuilder.ProcessorType = "DDSpacePointBuilder"
 FTDDDSpacePointBuilder.Parameters = {
     "SimHitSpacePointRelCollection": ["FTDSpacePointRelations"],
@@ -89,7 +82,6 @@ FTDDDSpacePointBuilder.Parameters = {
 }
 
 SETPlanarDigiProcessor = MarlinProcessorWrapper("SETPlanarDigiProcessor")
-SETPlanarDigiProcessor.OutputLevel = INFO
 SETPlanarDigiProcessor.ProcessorType = "DDPlanarDigiProcessor"
 SETPlanarDigiProcessor.Parameters = {
     "ForceHitsOntoSurface": ["true"],
@@ -103,7 +95,6 @@ SETPlanarDigiProcessor.Parameters = {
 }
 
 SETDDSpacePointBuilder = MarlinProcessorWrapper("SETDDSpacePointBuilder")
-SETDDSpacePointBuilder.OutputLevel = INFO
 SETDDSpacePointBuilder.ProcessorType = "DDSpacePointBuilder"
 SETDDSpacePointBuilder.Parameters = {
     "SimHitSpacePointRelCollection": ["SETSpacePointRelations"],
@@ -115,7 +106,6 @@ SETDDSpacePointBuilder.Parameters = {
 }
 
 MyTPCDigiProcessor = MarlinProcessorWrapper("MyTPCDigiProcessor")
-MyTPCDigiProcessor.OutputLevel = INFO
 MyTPCDigiProcessor.ProcessorType = "DDTPCDigiProcessor"
 MyTPCDigiProcessor.Parameters = {
     "DiffusionCoeffRPhi": ["0.025"],

--- a/StandardConfig/production/Tracking/TrackingDigi_FCCeeMDI.py
+++ b/StandardConfig/production/Tracking/TrackingDigi_FCCeeMDI.py
@@ -5,10 +5,8 @@
 # non-name parameters of Vertex and Inner D as for CLD (https://github.com/key4hep/CLDConfig/blob/main/CLDConfig/CLDReconstruction.py @ bbb0842)
 
 from Configurables import MarlinProcessorWrapper
-from Gaudi.Configuration import INFO
 
 VertexBarrelDigitiser = MarlinProcessorWrapper("VertexBarrelDigitiser")
-VertexBarrelDigitiser.OutputLevel = INFO
 VertexBarrelDigitiser.ProcessorType = "DDPlanarDigiProcessor"
 VertexBarrelDigitiser.Parameters = {
     "IsStrip": ["false"],
@@ -21,7 +19,6 @@ VertexBarrelDigitiser.Parameters = {
 }
 
 VertexEndcapDigitiser = MarlinProcessorWrapper("VertexEndcapDigitiser")
-VertexEndcapDigitiser.OutputLevel = INFO
 VertexEndcapDigitiser.ProcessorType = "DDPlanarDigiProcessor"
 VertexEndcapDigitiser.Parameters = {
     "IsStrip": ["false"],
@@ -34,7 +31,6 @@ VertexEndcapDigitiser.Parameters = {
 }
 
 InnerPlanarDigiProcessor = MarlinProcessorWrapper("InnerPlanarDigiProcessor")
-InnerPlanarDigiProcessor.OutputLevel = INFO
 InnerPlanarDigiProcessor.ProcessorType = "DDPlanarDigiProcessor"
 InnerPlanarDigiProcessor.Parameters = {
     "IsStrip": ["false"],
@@ -49,7 +45,6 @@ InnerPlanarDigiProcessor.Parameters = {
 InnerEndcapPlanarDigiProcessor = MarlinProcessorWrapper(
     "InnerEndcapPlanarDigiProcessor"
 )
-InnerEndcapPlanarDigiProcessor.OutputLevel = INFO
 InnerEndcapPlanarDigiProcessor.ProcessorType = "DDPlanarDigiProcessor"
 InnerEndcapPlanarDigiProcessor.Parameters = {
     "IsStrip": ["false"],
@@ -62,7 +57,6 @@ InnerEndcapPlanarDigiProcessor.Parameters = {
 }
 
 SETPlanarDigiProcessor = MarlinProcessorWrapper("SETPlanarDigiProcessor")
-SETPlanarDigiProcessor.OutputLevel = INFO
 SETPlanarDigiProcessor.ProcessorType = "DDPlanarDigiProcessor"
 SETPlanarDigiProcessor.Parameters = {
     "ForceHitsOntoSurface": ["true"],
@@ -76,7 +70,6 @@ SETPlanarDigiProcessor.Parameters = {
 }
 
 SETDDSpacePointBuilder = MarlinProcessorWrapper("SETDDSpacePointBuilder")
-SETDDSpacePointBuilder.OutputLevel = INFO
 SETDDSpacePointBuilder.ProcessorType = "DDSpacePointBuilder"
 SETDDSpacePointBuilder.Parameters = {
     "SimHitSpacePointRelCollection": ["SETSpacePointRelations"],
@@ -88,7 +81,6 @@ SETDDSpacePointBuilder.Parameters = {
 }
 
 MyTPCDigiProcessor = MarlinProcessorWrapper("MyTPCDigiProcessor")
-MyTPCDigiProcessor.OutputLevel = INFO
 MyTPCDigiProcessor.ProcessorType = "DDTPCDigiProcessor"
 MyTPCDigiProcessor.Parameters = {
     "DiffusionCoeffRPhi": ["0.025"],

--- a/StandardConfig/production/Tracking/TrackingReco.py
+++ b/StandardConfig/production/Tracking/TrackingReco.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-from Gaudi.Configuration import INFO
 from Configurables import MarlinProcessorWrapper
 
 MyClupatraProcessor = MarlinProcessorWrapper("MyClupatraProcessor")
-MyClupatraProcessor.OutputLevel = INFO
 MyClupatraProcessor.ProcessorType = "ClupatraProcessor"
 MyClupatraProcessor.Parameters = {
     "Chi2Cut": ["100"],
@@ -35,7 +33,6 @@ MyClupatraProcessor.Parameters = {
 }
 
 MySiliconTracking_MarlinTrk = MarlinProcessorWrapper("MySiliconTracking_MarlinTrk")
-MySiliconTracking_MarlinTrk.OutputLevel = INFO
 MySiliconTracking_MarlinTrk.ProcessorType = "SiliconTracking_MarlinTrk"
 MySiliconTracking_MarlinTrk.Parameters = {
     "AngleCutForMerging": ["0.1"],
@@ -107,7 +104,6 @@ MySiliconTracking_MarlinTrk.Parameters = {
 }
 
 MyForwardTracking = MarlinProcessorWrapper("MyForwardTracking")
-MyForwardTracking.OutputLevel = INFO
 MyForwardTracking.ProcessorType = "ForwardTracking"
 MyForwardTracking.Parameters = {
     "BestSubsetFinder": ["SubsetSimple"],
@@ -159,7 +155,6 @@ MyForwardTracking.Parameters = {
 }
 
 MyTrackSubsetProcessor = MarlinProcessorWrapper("MyTrackSubsetProcessor")
-MyTrackSubsetProcessor.OutputLevel = INFO
 MyTrackSubsetProcessor.ProcessorType = "TrackSubsetProcessor"
 MyTrackSubsetProcessor.Parameters = {
     "EnergyLossOn": ["true"],
@@ -173,7 +168,6 @@ MyTrackSubsetProcessor.Parameters = {
 }
 
 MyFullLDCTracking_MarlinTrk = MarlinProcessorWrapper("MyFullLDCTracking_MarlinTrk")
-MyFullLDCTracking_MarlinTrk.OutputLevel = INFO
 MyFullLDCTracking_MarlinTrk.ProcessorType = "FullLDCTracking_MarlinTrk"
 MyFullLDCTracking_MarlinTrk.Parameters = {
     "AngleCutForForcedMerging": ["0.05"],
@@ -243,7 +237,6 @@ MyFullLDCTracking_MarlinTrk.Parameters = {
 }
 
 MyCompute_dEdxProcessor = MarlinProcessorWrapper("MyCompute_dEdxProcessor")
-MyCompute_dEdxProcessor.OutputLevel = INFO
 MyCompute_dEdxProcessor.ProcessorType = "Compute_dEdxProcessor"
 MyCompute_dEdxProcessor.Parameters = {
     "AngularCorrectionParameters": ["0.635762", "-0.0573237"],
@@ -263,7 +256,6 @@ MyCompute_dEdxProcessor.Parameters = {
 }
 
 MyV0Finder = MarlinProcessorWrapper("MyV0Finder")
-MyV0Finder.OutputLevel = INFO
 MyV0Finder.ProcessorType = "V0Finder"
 MyV0Finder.Parameters = {
     "MassRangeGamma": ["0.01"],
@@ -273,7 +265,6 @@ MyV0Finder.Parameters = {
 }
 
 MyKinkFinder = MarlinProcessorWrapper("MyKinkFinder")
-MyKinkFinder.OutputLevel = INFO
 MyKinkFinder.ProcessorType = "KinkFinder"
 MyKinkFinder.Parameters = {
     "DebugPrinting": ["0"],
@@ -281,7 +272,6 @@ MyKinkFinder.Parameters = {
 }
 
 MyRefitProcessorKaon = MarlinProcessorWrapper("MyRefitProcessorKaon")
-MyRefitProcessorKaon.OutputLevel = INFO
 MyRefitProcessorKaon.ProcessorType = "RefitProcessor"
 MyRefitProcessorKaon.Parameters = {
     "EnergyLossOn": ["true"],
@@ -301,7 +291,6 @@ MyRefitProcessorKaon.Parameters = {
 }
 
 MyRefitProcessorProton = MarlinProcessorWrapper("MyRefitProcessorProton")
-MyRefitProcessorProton.OutputLevel = INFO
 MyRefitProcessorProton.ProcessorType = "RefitProcessor"
 MyRefitProcessorProton.Parameters = {
     "EnergyLossOn": ["true"],

--- a/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
+++ b/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from Configurables import MarlinProcessorWrapper
-from Gaudi.Configuration import INFO
 
 CT_MAX_DIST = "0.03;"  # semi-colon is important! RANDOM VALUE COPYIED FROM CLDRECO
 MCPartColName = ["MCParticle"]  # MCParticleCollectionName
@@ -10,7 +9,6 @@ VertexEndcapHitCollectionNames = ["VertexEndcapTrackerHits"]
 
 
 MyClupatraProcessor = MarlinProcessorWrapper("MyClupatraProcessor")
-MyClupatraProcessor.OutputLevel = INFO
 MyClupatraProcessor.ProcessorType = "ClupatraProcessor"
 MyClupatraProcessor.Parameters = {
     "Chi2Cut": ["100"],
@@ -41,7 +39,6 @@ MyClupatraProcessor.Parameters = {
 }
 
 MyConformalTracking = MarlinProcessorWrapper("MyConformalTracking")
-MyConformalTracking.OutputLevel = INFO
 MyConformalTracking.ProcessorType = "ConformalTrackingV2"
 MyConformalTracking.Parameters = {
     "DebugHits": ["DebugHits"],
@@ -92,7 +89,6 @@ MyConformalTracking.Parameters = {
 }
 
 MySiliconTracking_MarlinTrk = MarlinProcessorWrapper("MySiliconTracking_MarlinTrk")
-MySiliconTracking_MarlinTrk.OutputLevel = INFO
 MySiliconTracking_MarlinTrk.ProcessorType = "SiliconTracking_MarlinTrk"
 MySiliconTracking_MarlinTrk.Parameters = {
     "AngleCutForMerging": ["0.1"],
@@ -164,7 +160,6 @@ MySiliconTracking_MarlinTrk.Parameters = {
 }
 
 MyForwardTracking = MarlinProcessorWrapper("MyForwardTracking")
-MyForwardTracking.OutputLevel = INFO
 MyForwardTracking.ProcessorType = "ForwardTracking"
 MyForwardTracking.Parameters = {
     "BestSubsetFinder": ["SubsetSimple"],
@@ -216,7 +211,6 @@ MyForwardTracking.Parameters = {
 }
 
 MyTrackSubsetProcessor = MarlinProcessorWrapper("MyTrackSubsetProcessor")
-MyTrackSubsetProcessor.OutputLevel = INFO
 MyTrackSubsetProcessor.ProcessorType = "TrackSubsetProcessor"
 MyTrackSubsetProcessor.Parameters = {
     "EnergyLossOn": ["true"],
@@ -230,7 +224,6 @@ MyTrackSubsetProcessor.Parameters = {
 }
 
 MyFullLDCTracking_MarlinTrk = MarlinProcessorWrapper("MyFullLDCTracking_MarlinTrk")
-MyFullLDCTracking_MarlinTrk.OutputLevel = INFO
 MyFullLDCTracking_MarlinTrk.ProcessorType = "FullLDCTracking_MarlinTrk"
 MyFullLDCTracking_MarlinTrk.Parameters = {
     "AngleCutForForcedMerging": ["0.05"],
@@ -300,7 +293,6 @@ MyFullLDCTracking_MarlinTrk.Parameters = {
 }
 
 MyCompute_dEdxProcessor = MarlinProcessorWrapper("MyCompute_dEdxProcessor")
-MyCompute_dEdxProcessor.OutputLevel = INFO
 MyCompute_dEdxProcessor.ProcessorType = "Compute_dEdxProcessor"
 MyCompute_dEdxProcessor.Parameters = {
     "AngularCorrectionParameters": ["0.635762", "-0.0573237"],
@@ -320,7 +312,6 @@ MyCompute_dEdxProcessor.Parameters = {
 }
 
 MyV0Finder = MarlinProcessorWrapper("MyV0Finder")
-MyV0Finder.OutputLevel = INFO
 MyV0Finder.ProcessorType = "V0Finder"
 MyV0Finder.Parameters = {
     "MassRangeGamma": ["0.01"],
@@ -330,7 +321,6 @@ MyV0Finder.Parameters = {
 }
 
 MyKinkFinder = MarlinProcessorWrapper("MyKinkFinder")
-MyKinkFinder.OutputLevel = INFO
 MyKinkFinder.ProcessorType = "KinkFinder"
 MyKinkFinder.Parameters = {
     "DebugPrinting": ["0"],
@@ -338,7 +328,6 @@ MyKinkFinder.Parameters = {
 }
 
 MyRefitProcessorKaon = MarlinProcessorWrapper("MyRefitProcessorKaon")
-MyRefitProcessorKaon.OutputLevel = INFO
 MyRefitProcessorKaon.ProcessorType = "RefitProcessor"
 MyRefitProcessorKaon.Parameters = {
     "EnergyLossOn": ["true"],
@@ -358,7 +347,6 @@ MyRefitProcessorKaon.Parameters = {
 }
 
 MyRefitProcessorProton = MarlinProcessorWrapper("MyRefitProcessorProton")
-MyRefitProcessorProton.OutputLevel = INFO
 MyRefitProcessorProton.ProcessorType = "RefitProcessor"
 MyRefitProcessorProton.Parameters = {
     "EnergyLossOn": ["true"],


### PR DESCRIPTION
This allows the global output setting of Gaudi to actually apply to them. Otherwise it's not possible to set this globally.



BEGINRELEASENOTES
- Remove all `OutputLevel` settings from the wrapped Marlin processors in `ILDReconstruction.py` and components.

ENDRELEASENOTES

See also key4hep/k4MarlinWrapper#205 for the original source of this configuration.