### PR TITLE
Make sure that py_utils can be imported

### DIFF
--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -17,6 +17,9 @@ from Gaudi.Configuration import INFO
 from k4FWCore.parseArgs import parser
 from k4MarlinWrapper.parseConstants import parseConstants
 
+# Make sure we have the py_utils on the PYHTONPATH (but don't give them any more
+# importance than necessary)
+sys.path.append(Path(__file__).parent)
 from py_utils import SequenceLoader, import_from, parse_collection_patch_file
 
 # only non-FCCMDI models


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that the `py_utils` import works as expected by setting PYTHONPATH on the fly accordingly.

ENDRELEASENOTES

Fixes #154 