### PR TITLE
Introduce new constant to allow users to drop more collections

### DIFF
--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o1_v02.cfg
@@ -41,7 +41,7 @@ CONSTANTS = {
         "HCalEndcapRPCHits",
         "HCalECRingRPCHits",
     ],
-    "AdditionalDropCollectionsREC": "%(DropCollectionsHCal)s",
+    "DropCollectionsCalibrationREC": "%(DropCollectionsHCal)s",
     "dEdXErrorFactor": "7.55",
     "dEdXSmearingFactor": "0.035",
     "PidPDFFile": "HighLevelReco/PIDFiles/LikelihoodPID_Standard_l5_v01.root",

--- a/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l4_o2_v02.cfg
@@ -36,7 +36,7 @@ CONSTANTS = {
         "HcalEndcapRingCollection",
         "HcalEndcapsCollection",
     ],
-    "AdditionalDropCollectionsREC": "%(DropCollectionsHCal)s",
+    "DropCollectionsCalibrationREC": "%(DropCollectionsHCal)s",
     "dEdXErrorFactor": "7.55",
     "dEdXSmearingFactor": "0.035",
     "PidPDFFile": "HighLevelReco/PIDFiles/LikelihoodPID_Standard_l5_v01.root",

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v02.cfg
@@ -47,7 +47,7 @@ CONSTANTS = {
         "HCalEndcapRPCHits",
         "HCalECRingRPCHits",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v09.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o1_v09.cfg
@@ -47,7 +47,7 @@ CONSTANTS = {
         "HCalEndcapRPCHits",
         "HCalECRingRPCHits",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o2_v02.cfg
@@ -42,7 +42,7 @@ CONSTANTS = {
         "HcalEndcapRingCollection",
         "HcalEndcapsCollection",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o3_v02.cfg
@@ -47,7 +47,7 @@ CONSTANTS = {
         "HCalEndcapRPCHits",
         "HCalECRingRPCHits",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_o4_v02.cfg
@@ -42,7 +42,7 @@ CONSTANTS = {
         "HcalEndcapRingCollection",
         "HcalEndcapsCollection",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_l5_v11.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_l5_v11.cfg
@@ -47,7 +47,7 @@ CONSTANTS = {
         "HCalEndcapRPCHits",
         "HCalECRingRPCHits",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o1_v02.cfg
@@ -41,7 +41,7 @@ CONSTANTS = {
         "HCalEndcapRPCHits",
         "HCalECRingRPCHits",
     ],
-    "AdditionalDropCollectionsREC": "%(DropCollectionsHCal)s",
+    "DropCollectionsCalibrationREC": "%(DropCollectionsHCal)s",
     "dEdXErrorFactor": "8.53",
     "dEdXSmearingFactor": "0.044",
     "PidPDFFile": "HighLevelReco/PIDFiles/LikelihoodPID_Standard_s5_v01.root",

--- a/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s4_o2_v02.cfg
@@ -36,7 +36,7 @@ CONSTANTS = {
         "HcalEndcapRingCollection",
         "HcalEndcapsCollection",
     ],
-    "AdditionalDropCollectionsREC": "%(DropCollectionsHCal)s",
+    "DropCollectionsCalibrationREC": "%(DropCollectionsHCal)s",
     "dEdXErrorFactor": "8.53",
     "dEdXSmearingFactor": "0.044",
     "PidPDFFile": "HighLevelReco/PIDFiles/LikelihoodPID_Standard_s5_v01.root",

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o1_v02.cfg
@@ -47,7 +47,7 @@ CONSTANTS = {
         "HCalEndcapRPCHits",
         "HCalECRingRPCHits",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o2_v02.cfg
@@ -42,7 +42,7 @@ CONSTANTS = {
         "HcalEndcapRingCollection",
         "HcalEndcapsCollection",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o3_v02.cfg
@@ -47,7 +47,7 @@ CONSTANTS = {
         "HCalEndcapRPCHits",
         "HCalECRingRPCHits",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.cfg
+++ b/StandardConfig/production/Calibration/Calibration_ILD_s5_o4_v02.cfg
@@ -42,7 +42,7 @@ CONSTANTS = {
         "HcalEndcapRingCollection",
         "HcalEndcapsCollection",
     ],
-    "AdditionalDropCollectionsREC": [
+    "DropCollectionsCalibrationREC": [
         "%(DropCollectionsECal)s",
         "%(DropCollectionsHCal)s",
     ],

--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -20,7 +20,12 @@ from k4MarlinWrapper.parseConstants import parseConstants
 # Make sure we have the py_utils on the PYHTONPATH (but don't give them any more
 # importance than necessary)
 sys.path.append(Path(__file__).parent)
-from py_utils import SequenceLoader, import_from, parse_collection_patch_file
+from py_utils import (
+    SequenceLoader,
+    import_from,
+    parse_collection_patch_file,
+    get_drop_collections,
+)
 
 # only non-FCCMDI models
 DETECTOR_MODELS = (
@@ -332,8 +337,7 @@ if reco_args.lcioOutput != "only":
     edm4hepOutput = PodioOutput("EDM4hepOutput")
     edm4hepOutput.filename = f"{reco_args.outputFileBase}_REC.edm4hep.root"
     edm4hepOutput.outputCommands = ["keep *"]
-    for name in CONSTANTS["AdditionalDropCollectionsREC"].split(" "):
-        edm4hepOutput.outputCommands.append(f"drop {name}")
+    edm4hepOutput.outputCommands.extend(get_drop_collections(CONSTANTS, True))
 
     algList.append(edm4hepOutput)
 
@@ -343,7 +347,7 @@ if reco_args.lcioOutput in ("on", "only"):
     MyLCIOOutputProcessor.ProcessorType = "LCIOOutputProcessor"
     MyLCIOOutputProcessor.Parameters = {
         "CompressionLevel": ["6"],
-        "DropCollectionNames": [CONSTANTS["AdditionalDropCollectionsREC"]],
+        "DropCollectionNames": get_drop_collections(CONSTANTS, False),
         "LCIOOutputFile": [f"{reco_args.outputFileBase}_REC.slcio"],
         "LCIOWriteMode": ["WRITE_NEW"],
     }

--- a/StandardConfig/production/py_utils.py
+++ b/StandardConfig/production/py_utils.py
@@ -167,3 +167,25 @@ def parse_collection_patch_file(patch_file: Union[str, os.PathLike]) -> List[str
 
     # Flatten the list of lists into one large list
     return [s for strings in patch_colls for s in strings]
+
+
+def get_drop_collections(calib: Dict[str, str], cmds: bool) -> List[str]:
+    """Get the collections to drop from the calibration
+
+    Combine all the different sources for dropping collections into one list.
+    These sources are
+    - DropCollectionsCalibrationREC (i.e. the ones defined in the calibration)
+    - AdditionalDropCollectionsREC (i.e. user defined ones)
+
+    Args:
+        calib (Dict[str, str]): The calibration configuration
+        cmds (bool): Whether or not the list should be turned into a list of
+            keep / drop commands as used by EDM4hep output
+
+    Returns:
+        List [str]: A list of collections to drop
+    """
+    drop_calib = calib.get("DropCollectionsCalibrationREC", [])
+    drop_add = calib.get("AdditionalDropCollectionsREC", [])
+    prefix = "drop " if cmds else ""
+    return [f"{prefix}{c}" for c in drop_calib + drop_add]

--- a/StandardConfig/production/py_utils.py
+++ b/StandardConfig/production/py_utils.py
@@ -185,7 +185,10 @@ def get_drop_collections(calib: Dict[str, str], cmds: bool) -> List[str]:
     Returns:
         List [str]: A list of collections to drop
     """
-    drop_calib = calib.get("DropCollectionsCalibrationREC", [])
-    drop_add = calib.get("AdditionalDropCollectionsREC", [])
+    drop_calib = calib.get("DropCollectionsCalibrationREC", "")
+    drop_calib = drop_calib.split(" ") if drop_calib else []
+    drop_add = calib.get("AdditionalDropCollectionsREC", "")
+    drop_add = drop_add.split(" ") if drop_add else []
+
     prefix = "drop " if cmds else ""
     return [f"{prefix}{c}" for c in drop_calib + drop_add]


### PR DESCRIPTION

BEGINRELEASENOTES
- Introduce a `DropCollectionsCalibrationREC` for all the `CONSTANTS` configurations to free **`AdditionalDropCollectionsREC`** for user defined collections that should be dropped.
  - Introduce `get_drop_collections` function that does the appropriate merging.

ENDRELEASENOTES

Fixes #153 