### PR TITLE
Switch to upstreamed centrally available functionality

### DIFF
--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -295,7 +295,7 @@ if reco_args.lcioOutput != "only":
     # Make sure that all collections are always available by patching in missing
     # ones on-the-fly
     collPatcherRec = MarlinProcessorWrapper(
-        "CollPacherREC", ProcessorType="PatchCollections"
+        "CollPatcherREC", ProcessorType="PatchCollections"
     )
     collPatcherRec.Parameters = {
         "PatchCollections": parse_collection_patch_file(REC_COLLECTION_CONTENTS_FILE)

--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -183,7 +183,7 @@ sequenceLoader = SequenceLoader(
 
 
 if reco_args.inputFiles:
-    read = create_reader(reco_args.inputFiles)
+    read = create_reader(reco_args.inputFiles, evtsvc)
     read.OutputLevel = INFO
     algList.append(read)
 else:

--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -4,18 +4,16 @@ from pathlib import Path
 
 from Configurables import (
     ApplicationMgr,
-    EDM4hep2LcioTool,
     GeoSvc,
     Lcio2EDM4hepTool,
-    LcioEvent,
     MarlinProcessorWrapper,
-    PodioInput,
     PodioOutput,
     k4DataSvc,
 )
 from Gaudi.Configuration import INFO
 from k4FWCore.parseArgs import parser
 from k4MarlinWrapper.parseConstants import parseConstants
+from k4MarlinWrapper.inputReader import create_reader, attach_edm4hep2lcio_conversion
 
 # Make sure we have the py_utils on the PYHTONPATH (but don't give them any more
 # importance than necessary)
@@ -184,26 +182,6 @@ sequenceLoader = SequenceLoader(
 )
 
 
-def create_reader(input_files):
-    """Create the appropriate reader for the input files"""
-    if input_files[0].endswith(".slcio"):
-        if any(not f.endswith(".slcio") for f in input_files):
-            print("All input files need to have the same format (LCIO)")
-            sys.exit(1)
-
-        read = LcioEvent()
-        read.Files = input_files
-    else:
-        if any(not f.endswith(".root") for f in input_files):
-            print("All input files need to have the same format (EDM4hep)")
-            sys.exit(1)
-        read = PodioInput("PodioInput")
-        global evtsvc
-        evtsvc.inputs = input_files
-
-    return read
-
-
 if reco_args.inputFiles:
     read = create_reader(reco_args.inputFiles)
     read.OutputLevel = INFO
@@ -220,15 +198,6 @@ MyAIDAProcessor.Parameters = {
     "FileType": ["root"],
 }
 algList.append(MyAIDAProcessor)
-
-# We need to convert the inputs in case we have EDM4hep input
-if isinstance(read, PodioInput):
-    EDM4hep2LcioInput = EDM4hep2LcioTool("InputConversion")
-    EDM4hep2LcioInput.convertAll = True
-    # Adjust for the different naming conventions
-    EDM4hep2LcioInput.collNameMapping = {"MCParticles": "MCParticle"}
-    MyAIDAProcessor.EDM4hep2LcioTool = EDM4hep2LcioInput
-
 
 MyStatusmonitor = MarlinProcessorWrapper("MyStatusmonitor")
 MyStatusmonitor.ProcessorType = "Statusmonitor"
@@ -387,6 +356,8 @@ if reco_args.lcioOutput in ("on", "only"):
 
     algList.append(MyLCIOOutputProcessor)
     algList.append(DSTOutput)
+
+attach_edm4hep2lcio_conversion(algList, read)
 
 ApplicationMgr(
     TopAlg=algList, EvtSel="NONE", EvtMax=3, ExtSvc=svcList, OutputLevel=INFO


### PR DESCRIPTION

BEGINRELEASENOTES
- Use the `create_reader` and `attach_edm4hep2lcio_conversion` functionality that has been upstreamed to k4MarlinWrapper

ENDRELEASENOTES

Added in https://github.com/key4hep/k4MarlinWrapper/pull/179 