### PR TITLE
Switch to Ubuntu 24 nightlies for FCC models

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -95,7 +95,7 @@ jobs:
       matrix:
         detector_model: [ILD_FCCee_v01, ILD_FCCee_v02]
         key4hep_build: [sw-nightlies.hsf.org]
-        os: [ubuntu2204, el9]
+        os: [ubuntu2404, el9]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

BEGINRELEASENOTES
- Switch to Ubuntu24 for the CI workflows that test the FCCee models

ENDRELEASENOTES