### PR TITLE
Reduce the default verbosity to not flood logs

### DIFF
--- a/StandardConfig/production/MarlinStdReco.xml
+++ b/StandardConfig/production/MarlinStdReco.xml
@@ -112,7 +112,7 @@
     <parameter name="MaxRecordNumber" value="0"/>
     <parameter name="SkipNEvents" value="0"/>
     <parameter name="SupressCheck" value="false"/>
-    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG </parameter>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
     <parameter name="RandomSeed" value="1234567890" />
     <parameter name="OutputSteeringFile" value="MarlinStdRecoParsed.xml"/>
   </global>

--- a/StandardConfig/production/MarlinStdRecoLCTuple.xml
+++ b/StandardConfig/production/MarlinStdRecoLCTuple.xml
@@ -24,7 +24,7 @@
   <parameter name="MaxRecordNumber" value="0" />  
   <parameter name="SkipNEvents" value="0"/>  
   <parameter name="SupressCheck" value="false" />  
-  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">MESSAGE DEBUG  </parameter> 
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">MESSAGE </parameter>
   <parameter name="RandomSeed" value="1234567890" />
  </global>
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Set the default verbosity to `MESSAGE` for `MarlinStdReco.xml` and `MarlinStdRecoLCTuple.xml`

ENDRELEASENOTES