### PR TITLE
Refactor ConformalTrackingV2 Configuration

### DIFF
--- a/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
+++ b/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
@@ -40,6 +40,7 @@ MyClupatraProcessor.Parameters = {
 
 MyConformalTracking = MarlinProcessorWrapper("MyConformalTracking")
 MyConformalTracking.ProcessorType = "ConformalTrackingV2"
+# fmt: off
 MyConformalTracking.Parameters = {
     "DebugHits": ["DebugHits"],
     "DebugPlots": ["false"],
@@ -56,7 +57,6 @@ MyConformalTracking.Parameters = {
     "RetryTooManyTracks": ["false"],
     "SiTrackCollectionName": ["SiTracksCT"],
     "SortTreeResults": ["true"],
-    # fmt: off
     "Steps": [
         "[VertexBarrel]",
         "@Collections", ":", "VertexBarrelTrackerHits",
@@ -74,7 +74,6 @@ MyConformalTracking.Parameters = {
         "@Flags", ":", "HighPTFit,", "VertexToTracker,", "RadialSearch",
         "@Functions", ":", "CombineCollections,", "ExtendTracks",
     ],
-    # fmt: on
     "ThetaRange": ["0.05"],
     "TooManyTracks": ["100000"],
     "TrackerHitCollectionNames": [
@@ -87,9 +86,11 @@ MyConformalTracking.Parameters = {
     "VertexBarrelHitCollectionNames": VertexBarrelHitCollectionNames,
     "VertexEndcapHitCollectionNames": VertexEndcapHitCollectionNames,
 }
+# fmt: on
 
 MySiliconTracking_MarlinTrk = MarlinProcessorWrapper("MySiliconTracking_MarlinTrk")
 MySiliconTracking_MarlinTrk.ProcessorType = "SiliconTracking_MarlinTrk"
+# fmt: off
 MySiliconTracking_MarlinTrk.Parameters = {
     "AngleCutForMerging": ["0.1"],
     "AplySimpleUpdatedCoreBin": ["true"],
@@ -114,7 +115,6 @@ MySiliconTracking_MarlinTrk.Parameters = {
     "InitialTrackErrorPhi0": ["100"],
     "InitialTrackErrorTanL": ["100"],
     "InitialTrackErrorZ0": ["1e+06"],
-    # fmt: off
     "LayerCombinations": [
         "8","6","5",  "8","6","4",  "8","6","3",  "8","6","2",
         "8","5","3",  "8","5","2",  "8","4","3",  "8","4","2",
@@ -136,7 +136,6 @@ MySiliconTracking_MarlinTrk.Parameters = {
         "5","3","1",    "5","3","0",    "5","2","1",    "5","2","0",
         "4","3","1",    "4","3","0",    "4","2","1",    "4","2","0",
     ],
-    # fmt: on
     "MaxChi2PerHit": ["100"],
     "MaxHitsPerSector": ["100"],
     "MinDistCutAttach": ["2.5"],
@@ -158,6 +157,7 @@ MySiliconTracking_MarlinTrk.Parameters = {
     "UseSimpleAttachHitToTrack": ["true"],
     "VTXHitCollectionName": ["VXDTrackerHits"],
 }
+# fmt: on
 
 MyForwardTracking = MarlinProcessorWrapper("MyForwardTracking")
 MyForwardTracking.ProcessorType = "ForwardTracking"

--- a/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
+++ b/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 from Configurables import MarlinProcessorWrapper
+from py_utils import encode_CT_steps_dict_to_legacy_list
 
-CT_MAX_DIST = "0.03;"  # semi-colon is important! RANDOM VALUE COPYIED FROM CLDRECO
+CT_MAX_DIST = "0.03"  # RANDOM VALUE COPYIED FROM CLDRECO
 MCPartColName = ["MCParticle"]  # MCParticleCollectionName
 VertexBarrelHitCollectionNames = ["VertexBarrelTrackerHits"]
 VertexEndcapHitCollectionNames = ["VertexEndcapTrackerHits"]
@@ -40,7 +41,50 @@ MyClupatraProcessor.Parameters = {
 
 MyConformalTracking = MarlinProcessorWrapper("MyConformalTracking")
 MyConformalTracking.ProcessorType = "ConformalTrackingV2"
-# fmt: off
+conformal_tracking_steps_config = {
+    "VertexBarrel": {
+        "collections": ["VertexBarrelTrackerHits"],
+        "params": {
+            "MaxCellAngle": 0.01,
+            "MaxCellAngleRZ": 0.01,
+            "Chi2Cut": 100,
+            "MinClustersOnTrack": 4,
+            "MaxDistance": CT_MAX_DIST,
+            "SlopeZRange": 10.0,
+            "HighPTCut": 10.0,
+        },
+        "flags": ["HighPTFit", "VertexToTracker"],
+        "functions": ["CombineCollections", "BuildNewTracks"],
+    },
+    "VertexEncap": {
+        "collections": ["VertexEndcapTrackerHits"],
+        "params": {
+            "MaxCellAngle": 0.01,
+            "MaxCellAngleRZ": 0.01,
+            "Chi2Cut": 100,
+            "MinClustersOnTrack": 4,
+            "MaxDistance": CT_MAX_DIST,
+            "SlopeZRange": 10.0,
+            "HighPTCut": 10.0,
+        },
+        "flags": ["HighPTFit", "VertexToTracker"],
+        "functions": ["CombineCollections", "ExtendTracks"],
+    },
+    "Tracker": {
+        "collections": ["InnerTrackerBarrelHits", "InnerTrackerEndcapHits"],
+        "params": {
+            "MaxCellAngle": 0.1,
+            "MaxCellAngleRZ": 0.1,
+            "Chi2Cut": 2000,
+            "MinClustersOnTrack": 4,
+            "MaxDistance": CT_MAX_DIST,
+            "SlopeZRange": 10.0,
+            "HighPTCut": 1.0,
+        },
+        "flags": ["HighPTFit", "VertexToTracker", "RadialSearch"],
+        "functions": ["CombineCollections", "ExtendTracks"],
+    },
+}
 MyConformalTracking.Parameters = {
     "DebugHits": ["DebugHits"],
     "DebugPlots": ["false"],
@@ -57,23 +101,7 @@ MyConformalTracking.Parameters = {
     "RetryTooManyTracks": ["false"],
     "SiTrackCollectionName": ["SiTracksCT"],
     "SortTreeResults": ["true"],
-    "Steps": [
-        "[VertexBarrel]",
-        "@Collections", ":", "VertexBarrelTrackerHits",
-        "@Parameters", ":", "MaxCellAngle", ":", "0.01;", "MaxCellAngleRZ", ":", "0.01;", "Chi2Cut", ":", "100;", "MinClustersOnTrack", ":", "4;", "MaxDistance", ":", CT_MAX_DIST, "SlopeZRange:", "10.0;", "HighPTCut:", "10.0;",
-        "@Flags", ":", "HighPTFit,", "VertexToTracker",
-        "@Functions", ":", "CombineCollections,", "BuildNewTracks",
-        "[VertexEncap]",
-        "@Collections", ":", "VertexEndcapTrackerHits",
-        "@Parameters", ":", "MaxCellAngle", ":", "0.01;", "MaxCellAngleRZ", ":", "0.01;", "Chi2Cut", ":", "100;", "MinClustersOnTrack", ":", "4;", "MaxDistance", ":", CT_MAX_DIST, "SlopeZRange:", "10.0;", "HighPTCut:", "10.0;",
-        "@Flags", ":", "HighPTFit,", "VertexToTracker",
-        "@Functions", ":", "CombineCollections,", "ExtendTracks",
-        "[Tracker]",
-        "@Collections", ":", "InnerTrackerBarrelHits,", "InnerTrackerEndcapHits",
-        "@Parameters", ":", "MaxCellAngle", ":", "0.1;", "MaxCellAngleRZ", ":", "0.1;", "Chi2Cut", ":", "2000;", "MinClustersOnTrack", ":", "4;", "MaxDistance", ":", CT_MAX_DIST, "SlopeZRange:", "10.0;", "HighPTCut:", "1.0;",
-        "@Flags", ":", "HighPTFit,", "VertexToTracker,", "RadialSearch",
-        "@Functions", ":", "CombineCollections,", "ExtendTracks",
-    ],
+    "Steps": encode_CT_steps_dict_to_legacy_list(conformal_tracking_steps_config),
     "ThetaRange": ["0.05"],
     "TooManyTracks": ["100000"],
     "TrackerHitCollectionNames": [
@@ -86,7 +114,6 @@ MyConformalTracking.Parameters = {
     "VertexBarrelHitCollectionNames": VertexBarrelHitCollectionNames,
     "VertexEndcapHitCollectionNames": VertexEndcapHitCollectionNames,
 }
-# fmt: on
 
 MySiliconTracking_MarlinTrk = MarlinProcessorWrapper("MySiliconTracking_MarlinTrk")
 MySiliconTracking_MarlinTrk.ProcessorType = "SiliconTracking_MarlinTrk"

--- a/StandardConfig/production/py_utils.py
+++ b/StandardConfig/production/py_utils.py
@@ -192,3 +192,47 @@ def get_drop_collections(calib: Dict[str, str], cmds: bool) -> List[str]:
 
     prefix = "drop " if cmds else ""
     return [f"{prefix}{c}" for c in drop_calib + drop_add]
+
+
+def _append_commas_expect_last(config_list, list_to_add):
+    """Append a comma to each string in the list except the last one."""
+    config_list.extend([f"{ele}," for ele in list_to_add[:-1]] + [list_to_add[-1]])
+
+
+def encode_CT_steps_dict_to_legacy_list(steps_dict: dict) -> list[str]:
+    """
+    Encode the conformal tracking configuration into the list of strings that is expected by the Marlin processor
+    """
+    legacy_list = []
+
+    # Loop over steps
+    for step_name, step in steps_dict.items():
+        legacy_list.append(f"[{step_name}]")
+
+        # Collections
+        legacy_list.extend(["@Collections", ":"])
+        _append_commas_expect_last(legacy_list, step.get("collections"))
+
+        # Parameters
+        legacy_list.extend(["@Parameters", ":"])
+        for key, value in step.get("params", {}).items():
+            if key in ["SlopeZRange", "HighPTCut"]:
+                legacy_list.append(f"{key}:")
+            else:
+                legacy_list.append(str(key))
+                legacy_list.append(":")
+            legacy_list.append(f"{value};")
+
+        # Flags
+        flags = step.get("flags", [])
+        if flags:
+            legacy_list.extend(["@Flags", ":"])
+            _append_commas_expect_last(legacy_list, flags)
+
+        # Functions
+        functions = step.get("functions", [])
+        if functions:
+            legacy_list.extend(["@Functions", ":"])
+            _append_commas_expect_last(legacy_list, functions)
+
+    return legacy_list


### PR DESCRIPTION
BEGINRELEASENOTES

- fixes: wrong position of fmt off/on statements render them ineffective
- refactors the `ConformalTrackingV2` processor configuration in `TrackingReco_FCCeeMDI.py`

The previous manual string-list definition for the `Steps` parameter was unwieldy, especially with autoformatting that spread each item across a new line. This change introduces a new utility function, `encode_CT_steps_dict_to_legacy_list` in `py_utils.py`, allowing the conformal tracking steps to be defined using a structured Python dictionary.

This significantly improves readability and maintainability by:

- Presenting the configuration in a more intuitive, nested dictionary format.
- Reducing the number of lines occupied by the configuration, particularly after autoformatting.

This is a refactoring effort only; the physics behavior of `ConformalTrackingV2` should remain unchanged.

ENDRELEASENOTES