### PR TITLE
Refactor detector model cli args into mutually exclusive ones

### DIFF
--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -68,11 +68,14 @@ REC_COLLECTION_CONTENTS_FILE = "collections_rec_level.txt"
 
 det_mod_g = parser.add_mutually_exclusive_group(required=False)
 det_mod_g.add_argument(
-    "--compactFile", help="Compact detector file to use", type=str, default=None
+    "--compactFile",
+    help="Path to a custom DD4hep XML compact file to define the detector geometry",
+    type=str,
+    default=None,
 )
 det_mod_g.add_argument(
     "--detectorModel",
-    help="Which detector model to run reconstruction for",
+    help="Name of a registered detector model to use for reconstruction",
     choices=ALL_DETECTOR_MODELS,
     type=str,
     default=None,

--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -81,6 +81,20 @@ det_mod_g.add_argument(
     default=None,
 )
 
+beam_cal_reco_g = parser.add_mutually_exclusive_group(required=False)
+beam_cal_reco_g.add_argument(
+    "--runBeamCalReco",
+    help="Run the BeamCal reco",
+    action="store_true",
+    dest="runBeamCalReco",
+)
+beam_cal_reco_g.add_argument(
+    "--noBeamCalReco",
+    help="Don't run the BeamCal reco",
+    action="store_false",
+    dest="runBeamCalReco",
+)
+
 parser.add_argument(
     "--inputFiles",
     action="extend",
@@ -117,18 +131,6 @@ parser.add_argument(
     help="Run background overlay. NOTE: You have to make sure that the Overlay algorithms in "
     " BgOverlay/BgOverlay.py are provided with the necessary overlay files",
     action="store_true",
-)
-parser.add_argument(
-    "--runBeamCalReco",
-    help="Run the BeamCal reco",
-    action="store_true",
-    dest="runBeamCalReco",
-)
-parser.add_argument(
-    "--noBeamCalReco",
-    help="Don't run the BeamCal reco",
-    action="store_false",
-    dest="runBeamCalReco",
 )
 parser.add_argument(
     "--beamCalCalibFactor",


### PR DESCRIPTION

BEGINRELEASENOTES
- The selection of the detector model has been refactored into a mutually exclusive argument group, ensuring that only  one method of specification is used
- The beam cal reco arguments have been refactored into a mutually exclusive argument group as well

ENDRELEASENOTES