### PR TITLE
Make sure to load a tracking sequence for most geometries

### DIFF
--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -245,7 +245,7 @@ hcal_technology = CONSTANTS["HcalTechnology"]
 if det_model in FCCeeMDI_DETECTOR_MODELS:
     sequenceLoader.load("Tracking/TrackingDigi_FCCeeMDI")
     sequenceLoader.load("Tracking/TrackingReco_FCCeeMDI")
-elif det_model in DETECTOR_MODELS:
+else:
     sequenceLoader.load("Tracking/TrackingDigi")
     sequenceLoader.load("Tracking/TrackingReco")
 


### PR DESCRIPTION
The `elif` does not cover the non-specific models which results in a reco sequence without tracking.



BEGINRELEASENOTES
- Thank you for writing the text to appear in the release notes. It will show up
  exactly as it appears between the two bold lines
- ...

ENDRELEASENOTES