### PR TITLE
Ignore random output of DDKalTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@
 # Side product of running Marlin
 MarlinStdRecoParsed.xml
 
+# Side product of running DDKalTest
+DDKalTest_*
+
 # Output for ranlux
 Ranlux.coonf


### PR DESCRIPTION

BEGINRELEASENOTES
- Calling a processor, such as `RefitProcessor`, which calls `DDKalTest`, litters the repo with files such as
```bash
DDKalTest_BeampipeShell2_surfaces.txt
DDKalTest_Coil_surfaces.txt
DDKalTest_EcalEndcap_surfaces.txt    
```
- this PR adds `DDKalTest_*` to the `.gitignore`
ENDRELEASENOTES