### PR TITLE
Minor: fix misplaced "fmt off/on" statements

### DIFF
--- a/StandardConfig/production/HighLevelReco/HighLevelReco.py
+++ b/StandardConfig/production/HighLevelReco/HighLevelReco.py
@@ -146,16 +146,17 @@ MyDistilledPFOCreator.Parameters = {
 
 MyLikelihoodPID = MarlinProcessorWrapper("MyLikelihoodPID")
 MyLikelihoodPID.ProcessorType = "LikelihoodPIDProcessor"
+# fmt: off
+likelihood_pid_cost_matrix = [
+    "1.0e-50", "1.0", "1.5", "1.0", "1.5",
+    "1.0", "1.0e-50", "3.0", "1.0", "1.0",
+    "1.0", "1.0", "1.0e-50", "1.0", "3.0",
+    "1.0", "1.0", "4.0", "1.0e-50", "2.0",
+    "1.0", "1.0", "5.0", "1.0", "1.0e-50",
+]
+# fmt: on
 MyLikelihoodPID.Parameters = {
-    # fmt: off
-    "CostMatrix": [
-        "1.0e-50", "1.0", "1.5", "1.0", "1.5",
-        "1.0", "1.0e-50", "3.0", "1.0", "1.0",
-        "1.0", "1.0", "1.0e-50", "1.0", "3.0",
-        "1.0", "1.0", "4.0", "1.0e-50", "2.0",
-        "1.0", "1.0", "5.0", "1.0", "1.0e-50",
-    ],
-    # fmt: on
+    "CostMatrix": likelihood_pid_cost_matrix,
     "Debug": ["0"],
     "EnergyBoundaries": ["0", "1.0e+07"],
     "FilePDFName": [CONSTANTS["PidPDFFile"]],


### PR DESCRIPTION

BEGINRELEASENOTES
- Relocate misplaced formatting markers, rendering them effective.
- The intention with the markers remains to protect the more intuitive formatting of the matrix.
- Define the matrix before to keep formatting the other parameters of the processor.

ENDRELEASENOTES