### PR TITLE
Adding truth info for FCC-ee ILD model, add vertex resolutions as inp…

### DIFF
--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -163,6 +163,34 @@ parser.add_argument(
     action="store_true",
 )
 
+parser.add_argument(
+    "--VXDBarrelDigitiserResolutionU", 
+    action="store", 
+    default=["0.003"], 
+    help="Resolution in U direction for VXD Barrel digitisation", nargs="+"
+)
+
+parser.add_argument(
+    "--VXDBarrelDigitiserResolutionV", 
+    action="store", 
+    default=["0.003"], 
+    help="Resolution in V direction for VXD Barrel digitisation", nargs="+"
+)
+
+parser.add_argument(
+    "--VXDEndcapDigitiserResolutionU", 
+    action="store", 
+    default=["0.003"], 
+    help="Resolution in U direction for VXD Endcap digitisation", nargs="+"
+)
+
+parser.add_argument(
+    "--VXDEndcapDigitiserResolutionV", 
+    action="store", 
+    default=["0.003"], 
+    help="Resolution in V direction for VXD Endcap digitisation", nargs="+"
+)
+
 
 def get_compact_file_path(detector_model: str):
     """returns the compact file path to a specified detector model starting with the path stored in the 'K4GEO' environment variable"""
@@ -241,6 +269,10 @@ sequenceLoader = SequenceLoader(
         "CONSTANTS": CONSTANTS,
         "cms_energy_config": cms_energy_config,
         "using_particle_gun": reco_args.usingParticleGun,
+        "VXDBarrelDigitiserResolutionU": reco_args.VXDBarrelDigitiserResolutionU,
+        "VXDBarrelDigitiserResolutionV": reco_args.VXDBarrelDigitiserResolutionV,
+        "VXDEndcapDigitiserResolutionU": reco_args.VXDEndcapDigitiserResolutionU,
+        "VXDEndcapDigitiserResolutionV": reco_args.VXDEndcapDigitiserResolutionV,
     },
 )
 
@@ -295,6 +327,67 @@ if not reco_args.trackingOnly:
 
     if not is_FCCee_model:
         sequenceLoader.load("HighLevelReco/HighLevelReco")
+    else:
+        MyRecoMCTruthLinker = MarlinProcessorWrapper("MyRecoMCTruthLinker")
+        MyRecoMCTruthLinker.ProcessorType = "RecoMCTruthLinker"
+        MyRecoMCTruthLinker.Parameters = {
+            "CalohitMCTruthLinkName": ["CalohitMCTruthLink"],
+            "ClusterCollection": ["PandoraClusters"],
+            "ClusterMCTruthLinkName": ["ClusterMCTruthLink"],
+            "FullRecoRelation": ["true"],
+            "KeepDaughtersPDG": ["22", "111", "310", "13", "211", "321"],
+            "MCParticleCollection": ["MCParticle"],
+            "MCParticlesSkimmedName": ["MCParticlesSkimmed"],
+            "MCTruthClusterLinkName": ["MCTruthClusterLink"],
+            "MCTruthRecoLinkName": ["MCTruthRecoLink"],
+            "MCTruthTrackLinkName": ["MCTruthMarlinTrkTracksLink"],
+            "RecoMCTruthLinkName": ["RecoMCTruthLink"],
+            "RecoParticleCollection": ["PandoraPFOs"],
+            "SimCaloHitCollections": [
+                "BeamCalCollection",
+                "LHCalCollection",
+                "LumiCalCollection",
+                CONSTANTS["ECalSimHitCollections"],
+                CONSTANTS["HCalSimHitCollections"],
+                "YokeBarrelCollection",
+                "YokeEndcapsCollection",
+            ],
+            "SimCalorimeterHitRelationNames": [
+                "EcalBarrelRelationsSimRec",
+                "EcalEndcapRingRelationsSimRec",
+                "EcalEndcapsRelationsSimRec",
+                "HcalBarrelRelationsSimRec",
+                "HcalEndcapRingRelationsSimRec",
+                "HcalEndcapsRelationsSimRec",
+                "RelationLHcalHit",
+                "RelationMuonHit",
+                "RelationLcalHit",
+                "RelationBCalHit",
+            ],
+            "SimTrackerHitCollections": [
+                "VXDCollection",
+                "SITCollection",
+                "FTD_PIXELCollection",
+                "FTD_STRIPCollection",
+                "TPCCollection",
+                "SETCollection",
+            ],
+            "TrackCollection": ["MarlinTrkTracks"],
+            "TrackMCTruthLinkName": ["MarlinTrkTracksMCTruthLink"],
+            "TrackerHitsRelInputCollections": [
+                "VXDTrackerHitRelations",
+                "SITTrackerHitRelations",
+                "FTDPixelTrackerHitRelations",
+                "FTDSpacePointRelations",
+                "TPCTrackerHitRelations",
+                "SETSpacePointRelations",
+            ],
+            "UseTrackerHitRelations": ["true"],
+            "UsingParticleGun": ["true"],
+        }
+        algList.append(MyRecoMCTruthLinker)
+
+
 
     if not reco_args.noPFO:
         MyPfoAnalysis = MarlinProcessorWrapper("MyPfoAnalysis")

--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -325,9 +325,7 @@ if not reco_args.trackingOnly:
     if reco_args.runBeamCalReco:
         sequenceLoader.load("HighLevelReco/BeamCalReco")
 
-    if not is_FCCee_model:
-        sequenceLoader.load("HighLevelReco/HighLevelReco")
-    else:
+    if is_FCCee_model:
         MyRecoMCTruthLinker = MarlinProcessorWrapper("MyRecoMCTruthLinker")
         MyRecoMCTruthLinker.ProcessorType = "RecoMCTruthLinker"
         MyRecoMCTruthLinker.Parameters = {
@@ -386,6 +384,8 @@ if not reco_args.trackingOnly:
             "UsingParticleGun": ["true"],
         }
         algList.append(MyRecoMCTruthLinker)
+    else:
+        sequenceLoader.load("HighLevelReco/HighLevelReco")
 
 
 

--- a/StandardConfig/production/ILDReconstruction.py
+++ b/StandardConfig/production/ILDReconstruction.py
@@ -167,28 +167,28 @@ parser.add_argument(
     "--VXDBarrelDigitiserResolutionU", 
     action="store", 
     default=["0.003"], 
-    help="Resolution in U direction for VXD Barrel digitisation", nargs="+"
+    help="Resolution in U direction for VXD Barrel digitisation. Only used for FCC models", nargs="+"
 )
 
 parser.add_argument(
     "--VXDBarrelDigitiserResolutionV", 
     action="store", 
     default=["0.003"], 
-    help="Resolution in V direction for VXD Barrel digitisation", nargs="+"
+    help="Resolution in V direction for VXD Barrel digitisation. Only used for FCC models", nargs="+"
 )
 
 parser.add_argument(
     "--VXDEndcapDigitiserResolutionU", 
     action="store", 
     default=["0.003"], 
-    help="Resolution in U direction for VXD Endcap digitisation", nargs="+"
+    help="Resolution in U direction for VXD Endcap digitisation. Only used for FCC models", nargs="+"
 )
 
 parser.add_argument(
     "--VXDEndcapDigitiserResolutionV", 
     action="store", 
     default=["0.003"], 
-    help="Resolution in V direction for VXD Endcap digitisation", nargs="+"
+    help="Resolution in V direction for VXD Endcap digitisation. Only used for FCC models", nargs="+"
 )
 
 
@@ -325,69 +325,8 @@ if not reco_args.trackingOnly:
     if reco_args.runBeamCalReco:
         sequenceLoader.load("HighLevelReco/BeamCalReco")
 
-    if is_FCCee_model:
-        MyRecoMCTruthLinker = MarlinProcessorWrapper("MyRecoMCTruthLinker")
-        MyRecoMCTruthLinker.ProcessorType = "RecoMCTruthLinker"
-        MyRecoMCTruthLinker.Parameters = {
-            "CalohitMCTruthLinkName": ["CalohitMCTruthLink"],
-            "ClusterCollection": ["PandoraClusters"],
-            "ClusterMCTruthLinkName": ["ClusterMCTruthLink"],
-            "FullRecoRelation": ["true"],
-            "KeepDaughtersPDG": ["22", "111", "310", "13", "211", "321"],
-            "MCParticleCollection": ["MCParticle"],
-            "MCParticlesSkimmedName": ["MCParticlesSkimmed"],
-            "MCTruthClusterLinkName": ["MCTruthClusterLink"],
-            "MCTruthRecoLinkName": ["MCTruthRecoLink"],
-            "MCTruthTrackLinkName": ["MCTruthMarlinTrkTracksLink"],
-            "RecoMCTruthLinkName": ["RecoMCTruthLink"],
-            "RecoParticleCollection": ["PandoraPFOs"],
-            "SimCaloHitCollections": [
-                "BeamCalCollection",
-                "LHCalCollection",
-                "LumiCalCollection",
-                CONSTANTS["ECalSimHitCollections"],
-                CONSTANTS["HCalSimHitCollections"],
-                "YokeBarrelCollection",
-                "YokeEndcapsCollection",
-            ],
-            "SimCalorimeterHitRelationNames": [
-                "EcalBarrelRelationsSimRec",
-                "EcalEndcapRingRelationsSimRec",
-                "EcalEndcapsRelationsSimRec",
-                "HcalBarrelRelationsSimRec",
-                "HcalEndcapRingRelationsSimRec",
-                "HcalEndcapsRelationsSimRec",
-                "RelationLHcalHit",
-                "RelationMuonHit",
-                "RelationLcalHit",
-                "RelationBCalHit",
-            ],
-            "SimTrackerHitCollections": [
-                "VXDCollection",
-                "SITCollection",
-                "FTD_PIXELCollection",
-                "FTD_STRIPCollection",
-                "TPCCollection",
-                "SETCollection",
-            ],
-            "TrackCollection": ["MarlinTrkTracks"],
-            "TrackMCTruthLinkName": ["MarlinTrkTracksMCTruthLink"],
-            "TrackerHitsRelInputCollections": [
-                "VXDTrackerHitRelations",
-                "SITTrackerHitRelations",
-                "FTDPixelTrackerHitRelations",
-                "FTDSpacePointRelations",
-                "TPCTrackerHitRelations",
-                "SETSpacePointRelations",
-            ],
-            "UseTrackerHitRelations": ["true"],
-            "UsingParticleGun": ["true"],
-        }
-        algList.append(MyRecoMCTruthLinker)
-    else:
+    if not is_FCCee_model:
         sequenceLoader.load("HighLevelReco/HighLevelReco")
-
-
 
     if not reco_args.noPFO:
         MyPfoAnalysis = MarlinProcessorWrapper("MyPfoAnalysis")

--- a/StandardConfig/production/Tracking/TrackingDigi_FCCeeMDI.py
+++ b/StandardConfig/production/Tracking/TrackingDigi_FCCeeMDI.py
@@ -10,11 +10,11 @@ VertexBarrelDigitiser = MarlinProcessorWrapper("VertexBarrelDigitiser")
 VertexBarrelDigitiser.ProcessorType = "DDPlanarDigiProcessor"
 VertexBarrelDigitiser.Parameters = {
     "IsStrip": ["false"],
-    "ResolutionU": ["0.003", "0.003", "0.003", "0.003", "0.003", "0.003"],
-    "ResolutionV": ["0.003", "0.003", "0.003", "0.003", "0.003", "0.003"],
+    "ResolutionU": [str(x) for x in VXDBarrelDigitiserResolutionU],
+    "ResolutionV": [str(x) for x in VXDBarrelDigitiserResolutionV],
     "SimTrackHitCollectionName": ["VertexBarrelCollection"],
     "SimTrkHitRelCollection": ["VertexBarrelTrackerHitRelations"],
-    "SubDetectorName": ["VertexBarrel"],
+    "SubDetectorName": ["Vertex"],
     "TrackerHitCollectionName": ["VertexBarrelTrackerHits"],
 }
 
@@ -22,11 +22,11 @@ VertexEndcapDigitiser = MarlinProcessorWrapper("VertexEndcapDigitiser")
 VertexEndcapDigitiser.ProcessorType = "DDPlanarDigiProcessor"
 VertexEndcapDigitiser.Parameters = {
     "IsStrip": ["false"],
-    "ResolutionU": ["0.003", "0.003", "0.003", "0.003", "0.003", "0.003"],
-    "ResolutionV": ["0.003", "0.003", "0.003", "0.003", "0.003", "0.003"],
+    "ResolutionU": [str(x) for x in VXDEndcapDigitiserResolutionU],
+    "ResolutionV": [str(x) for x in VXDEndcapDigitiserResolutionV],
     "SimTrackHitCollectionName": ["VertexEndcapCollection"],
     "SimTrkHitRelCollection": ["VertexEndcapTrackerHitRelations"],
-    "SubDetectorName": ["VertexEndcap"],
+    "SubDetectorName": ["Vertex"],
     "TrackerHitCollectionName": ["VertexEndcapTrackerHits"],
 }
 

--- a/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
+++ b/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
@@ -4,7 +4,7 @@ from Configurables import MarlinProcessorWrapper
 
 from py_utils import encode_CT_steps_dict_to_legacy_list
 
-CT_MAX_DIST = "0.03"  # RANDOM VALUE COPYIED FROM CLDRECO
+CT_MAX_DIST = "0.05"  # RANDOM VALUE COPYIED FROM CLDRECO
 MCPartColName = ["MCParticle"]  # MCParticleCollectionName
 VertexBarrelHitCollectionNames = ["VertexBarrelTrackerHits"]
 VertexEndcapHitCollectionNames = ["VertexEndcapTrackerHits"]
@@ -38,7 +38,7 @@ MyClupatraProcessor.Parameters = {
     "TrackStartsInnerDist": ["25"],
     "TrackSystemName": ["DDKalTest"],
     "VXDHitCollection": ["VertexBarrelTrackerHits"],
-    "VXDDetectorName": ["VertexBarrel"],
+    "VXDDetectorName": ["Vertex"],
     "pickUpSiHits": ["true"],
 }
 
@@ -46,7 +46,7 @@ MyConformalTracking = MarlinProcessorWrapper("MyConformalTracking")
 MyConformalTracking.ProcessorType = "ConformalTrackingV2"
 conformal_tracking_steps_config = {
     # Based on CLD's Reconstruction in CLDConfig
-    "VertexBarrel": {
+    "Vertex": {
         "collections": ["VertexBarrelTrackerHits"],
         "params": {
             "MaxCellAngle": 0.01,
@@ -60,7 +60,7 @@ conformal_tracking_steps_config = {
         "flags": ["HighPTFit", "VertexToTracker"],
         "functions": ["CombineCollections", "BuildNewTracks"],
     },
-    "VertexEncap": {
+    "Vertex": {
         "collections": ["VertexEndcapTrackerHits"],
         "params": {
             "MaxCellAngle": 0.01,
@@ -92,20 +92,20 @@ conformal_tracking_steps_config = {
         "flags": ["HighPTFit", "VertexToTracker", "RadialSearch"],
         "functions": ["CombineCollections", "BuildNewTracks"],
     },
-    #    "LowerCellAngle2": {
-    #        "collections": "",
-    #        "params": {
-    #            "MaxCellAngle": 0.1,
-    #            "MaxCellAngleRZ": 0.1,
-    #            "Chi2Cut": 2000,
-    #            "MinClustersOnTrack": 4,
-    #            "MaxDistance": CT_MAX_DIST,
-    #            "SlopeZRange": 10.0,
-    #            "HighPTCut": 10.0,
-    #        },
-    #        "flags": ["HighPTFit", "VertexToTracker", "RadialSearch"],
-    #        "functions": ["BuildNewTracks","SortTracks"],
-    #    },
+    "LowerCellAngle2": {
+        "collections": [""],
+        "params": {
+            "MaxCellAngle": 0.1,
+            "MaxCellAngleRZ": 0.1,
+            "Chi2Cut": 2000,
+            "MinClustersOnTrack": 4,
+            "MaxDistance": CT_MAX_DIST,
+            "SlopeZRange": 10.0,
+            "HighPTCut": 10.0,
+        },
+        "flags": ["HighPTFit", "VertexToTracker", "RadialSearch"],
+        "functions": ["BuildNewTracks","SortTracks"],
+    },
     "Tracker": {
         "collections": ["InnerTrackerBarrelHits", "InnerTrackerEndcapHits"],
         "params": {

--- a/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
+++ b/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
@@ -4,7 +4,7 @@ from Configurables import MarlinProcessorWrapper
 
 from py_utils import encode_CT_steps_dict_to_legacy_list
 
-CT_MAX_DIST = "0.05"  # RANDOM VALUE COPYIED FROM CLDRECO
+CT_MAX_DIST = "0.05"  # COPYIED FROM CLDRECO, valid for vertex detector with first layer close to IP (like in CLD_o2)
 MCPartColName = ["MCParticle"]  # MCParticleCollectionName
 VertexBarrelHitCollectionNames = ["VertexBarrelTrackerHits"]
 VertexEndcapHitCollectionNames = ["VertexEndcapTrackerHits"]

--- a/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
+++ b/StandardConfig/production/Tracking/TrackingReco_FCCeeMDI.py
@@ -42,6 +42,7 @@ MyClupatraProcessor.Parameters = {
     "pickUpSiHits": ["false"],
 }
 
+MyClupatraProcessorFCC = MarlinProcessorWrapper("MyClupatraProcessor")
 MyClupatraProcessorFCC.ProcessorType = "ClupatraProcessor"
 MyClupatraProcessorFCC.Parameters = {
     "Chi2Cut": ["100"],


### PR DESCRIPTION
…ut arguments, update vertex detector naming scheme to be compliant also with FCC-SEED VXD (backwards compatible with CLD VXD), updating CT_MAX_DIST value to use the same as CLD with smaller beam pipe



BEGINRELEASENOTES
- Enable usage of FCC-SEED VXD with updated VXD system strings (backwards compatible with CLD VXD), see https://github.com/key4hep/k4geo/pull/612 
- Updating `CT_MAX_DIST` to correct value ([like in CLD](https://github.com/key4hep/CLDConfig/blob/8d52b4611f493c709a084747d9906e4a123822d9/CLDConfig/Tracking/ConformalTracking.py#L26))
- Enabling additonal low cell angle step in conformal tracking ([like in CLD](https://github.com/key4hep/CLDConfig/blob/8d52b4611f493c709a084747d9906e4a123822d9/CLDConfig/Tracking/ConformalTracking.py#L79))
ENDRELEASENOTES