### PR TITLE
Remove unused Tracking package initializer

### DIFF
--- a/StandardConfig/production/Tracking/__init__.py
+++ b/StandardConfig/production/Tracking/__init__.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python3


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove unused Tracking package initializer

ENDRELEASENOTES

Loading is done through `SequenceLoader` so there is no need to have this as a python package and can be part of the reason why conflicts like https://github.com/key4hep/k4RecTracker/issues/90 are found.